### PR TITLE
chore(perf-check): install bench wizard as part of the check perf script

### DIFF
--- a/scripts/check_performance.sh
+++ b/scripts/check_performance.sh
@@ -28,7 +28,7 @@ fi
 echo "OK"
 
 echo -n "Toolchain ...... "
-TOOLCHAIN=`rustup default`
+TOOLCHAIN=$(rustup default)
 
 if [[ $TOOLCHAIN = "nightly"* ]]
 then
@@ -62,12 +62,26 @@ $PYTHON -m bench_wizard >/dev/null 2>&1 || {
     exit 1
   fi
 }
-CURRENT_BENCH_VERSION=`$PYTHON -m bench_wizard version | tr -d '\n'`
+
+CURRENT_BENCH_VERSION=$($PYTHON -m bench_wizard version | tr -d '\n')
 
 if [[ $EXPECTED_BENCHWIZARD_VERSION > $CURRENT_BENCH_VERSION ]]
 then
 	echo "Please upgrade benchwizard (current version $CURRENT_BENCH_VERSION): pip3 install bench-wizard --upgrade";
-  exit 1;
+	read -p "Do you want to upgrade it now? [Y/n] " -n 1 -r
+  echo    # move to a new line
+  if [[ ! $REPLY =~ ^[Yy]$ ]]
+  then
+      exit 1
+  fi
+
+  pip3 install bench-wizard --upgrade > /dev/null
+
+  if [[ $? != 0 ]];
+  then
+    echo "benchwizard upgrade failed."
+    exit 1
+  fi
 fi
 
 echo

--- a/scripts/check_performance.sh
+++ b/scripts/check_performance.sh
@@ -46,9 +46,22 @@ echo -n "benchwizard >= $EXPECTED_BENCHWIZARD_VERSION ..... "
 $PYTHON -m bench_wizard >/dev/null 2>&1 || {
   echo "benchwizard required. benchwizard is cli tool developed by HydraDX dev to streamline substrate benchmark process.";
   echo "Installation: pip3 install bench-wizard";
-  exit 1;
-  }
+  echo
+  read -p "Do you want to install it now? [Y/n] " -n 1 -r
+  echo    # move to a new line
+  if [[ ! $REPLY =~ ^[Yy]$ ]]
+  then
+      exit 1
+  fi
 
+  pip3 install bench-wizard > /dev/null
+
+  if [[ $? != 0 ]];
+  then
+    echo "benchwizard installation failed."
+    exit 1
+  fi
+}
 CURRENT_BENCH_VERSION=`$PYTHON -m bench_wizard version | tr -d '\n'`
 
 if [[ $EXPECTED_BENCHWIZARD_VERSION > $CURRENT_BENCH_VERSION ]]


### PR DESCRIPTION
## Description
Install bench-wizard cli tool as part of the check_performance script. 


## Related Issue
#167 

## Motivation and Context
Currently, the script exists and user has to manually install the tool and rerun the script afterwards. This change helps with that ,so no need to exit, install and rerun again.

## How Has This Been Tested?
Manually on benchbot machine.

