### PR TITLE
fix!:  set DOLLARS constant to correct number

### DIFF
--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -2,7 +2,7 @@ pub mod currency {
 	pub use primitives::Balance;
 
 	pub const HDX: Balance = 1_000_000_000_000;
-	pub const DOLLARS: Balance = HDX / 10;	// 10 HDX ~= 1 $
+	pub const DOLLARS: Balance = HDX * 10;	// 10 HDX ~= 1 $
 	pub const CENTS: Balance = DOLLARS / 100;
 	pub const MILLICENTS: Balance = CENTS / 1_000;
 }


### PR DESCRIPTION
We've set wrong DOLLARS constant the transactions are too cheap and the storage for identities is 0.05$ instead of 5$
