### PR TITLE
fix(multi-payment): move balances dependency to dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "hydra-dx"
-version = "3.0.1"
+version = "3.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "hydra-dx-runtime"
-version = "9.0.0"
+version = "11.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -2443,7 +2443,7 @@ dependencies = [
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances 3.0.0",
+ "pallet-balances 3.0.1",
  "pallet-claims",
  "pallet-collective",
  "pallet-democracy",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-amm"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-registry"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4257,7 +4257,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4274,7 +4274,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-claims"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4285,7 +4285,7 @@ dependencies = [
  "orml-tokens",
  "orml-traits",
  "orml-utilities",
- "pallet-balances 3.0.0 (git+https://github.com/paritytech/substrate?branch=rococo-v1)",
+ "pallet-balances 3.0.0",
  "parity-scale-codec 2.1.1",
  "primitives",
  "rustc-hex",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-exchange"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4384,7 +4384,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-exchange-benchmarking"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-faucet"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4426,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-genesis-history"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "derive_more",
  "frame-support",
@@ -4529,7 +4529,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "pallet-balances 3.0.0 (git+https://github.com/paritytech/substrate?branch=rococo-v1)",
+ "pallet-balances 3.0.0",
  "parity-scale-codec 2.1.1",
  "serde",
  "sp-runtime",
@@ -4664,7 +4664,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-multi-payment"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4740,7 +4740,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
- "pallet-balances 3.0.0 (git+https://github.com/paritytech/substrate?branch=rococo-v1)",
+ "pallet-balances 3.0.0",
  "parity-scale-codec 2.1.1",
  "serde",
  "sp-runtime",
@@ -7939,7 +7939,7 @@ name = "substrate-fixed"
 version = "0.5.6"
 source = "git+https://github.com/encointer/substrate-fixed#b33d186888c60f38adafcfc0ec3a21aab263aef1"
 dependencies = [
- "parity-scale-codec 2.0.1",
+ "parity-scale-codec 2.1.1",
  "typenum",
 ]
 

--- a/pallets/transaction-multi-payment/Cargo.toml
+++ b/pallets/transaction-multi-payment/Cargo.toml
@@ -6,7 +6,7 @@ homepage = 'https://github.com/galacticcouncil/hydra-dx'
 license = 'Apache 2.0'
 name = 'pallet-transaction-multi-payment'
 repository = 'https://github.com/galacticcouncil/hydra-dx'
-version = '3.0.1'
+version = '3.0.2'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/pallets/transaction-multi-payment/Cargo.toml
+++ b/pallets/transaction-multi-payment/Cargo.toml
@@ -26,8 +26,6 @@ primitive-types = {default-features = false, version = '0.8.0'}
 serde = {features = ['derive'], optional = true, version = '1.0.101'}
 
 # Local dependecies
-pallet-amm = {path = '../amm', default-features = false}
-pallet-asset-registry = {path = '../asset-registry', default-features = false}
 primitives = {path = '../../primitives', default-features = false}
 
 # ORML dependencies
@@ -43,12 +41,13 @@ sp-core = {default-features = false, version = '3.0.0'}
 sp-runtime = {default-features = false, version = '3.0.0'}
 sp-std = {default-features = false, version = '3.0.0'}
 
-pallet-balances = {path = '../balances', default-features = false, version = '3.0.0'}
 pallet-transaction-payment = {default-features = false, version = '3.0.0'}
 
 [dev-dependencies]
+pallet-balances = {default-features = false, version = '3.0.0'}
 orml-currencies = {default-features = false, version = "0.4.1-dev"}
-pallet-transaction-payment = {default-features = false, version = '3.0.0'}
+pallet-amm = {path = '../amm', default-features = false}
+pallet-asset-registry = {path = '../asset-registry', default-features = false}
 sp-io = {default-features = false, version = '3.0.0'}
 
 [features]
@@ -63,7 +62,4 @@ std = [
   'sp-runtime/std',
   'orml-tokens/std',
   'orml-traits/std',
-  'pallet-balances/std',
-  'pallet-asset-registry/std',
-  'pallet-amm/std',
 ]

--- a/pallets/transaction-multi-payment/benchmarking/Cargo.toml
+++ b/pallets/transaction-multi-payment/benchmarking/Cargo.toml
@@ -27,7 +27,7 @@ serde = {features = ['derive'], optional = true, version = '1.0.101'}
 # Local dependencies
 pallet-amm = {path = '../../amm', default-features = false}
 pallet-asset-registry = {path = '../../asset-registry', default-features = false}
-pallet-balances = {path = '../../balances', default-features = false}
+pallet-balances = {default-features = false}
 pallet-transaction-multi-payment = {path = '../../transaction-multi-payment', default-features = false}
 primitives = {path = '../../../primitives', default-features = false}
 

--- a/pallets/transaction-multi-payment/benchmarking/Cargo.toml
+++ b/pallets/transaction-multi-payment/benchmarking/Cargo.toml
@@ -27,7 +27,6 @@ serde = {features = ['derive'], optional = true, version = '1.0.101'}
 # Local dependencies
 pallet-amm = {path = '../../amm', default-features = false}
 pallet-asset-registry = {path = '../../asset-registry', default-features = false}
-pallet-balances = {default-features = false}
 pallet-transaction-multi-payment = {path = '../../transaction-multi-payment', default-features = false}
 primitives = {path = '../../../primitives', default-features = false}
 
@@ -43,9 +42,10 @@ frame-support = {default-features = false, version = '3.0.0'}
 frame-system = {default-features = false, version = '3.0.0'}
 frame-system-benchmarking = {default-features = false, version = '3.0.0'}
 
+pallet-balances = {default-features = false, version = "3.0.0"}
 pallet-transaction-payment = {default-features = false, version = '3.0.0'}
-sp-std = {default-features = false, version = '3.0.0'}
 
+sp-std = {default-features = false, version = '3.0.0'}
 sp-core = {default-features = false, version = '3.0.0'}
 sp-runtime = {default-features = false, version = '3.0.0'}
 

--- a/pallets/transaction-multi-payment/benchmarking/Cargo.toml
+++ b/pallets/transaction-multi-payment/benchmarking/Cargo.toml
@@ -6,7 +6,7 @@ homepage = 'https://github.com/galacticcouncil/hydra-dx'
 license = 'Apache 2.0'
 name = 'pallet-multi-payment-benchmarking'
 repository = 'https://github.com/galacticcouncil/hydra-dx'
-version = '3.0.0'
+version = '3.0.2'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']


### PR DESCRIPTION
## Description
transaction-multi-payment pallet has dependency on local balances pallet implementation. This is only dev dependency used in test.

This PR moves the dependency to dev dependencies section and it changes to use substrate balances instead of local balances.