### PR TITLE
fix(chore): discard patch for libsrock-db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "hydra-dx-runtime"
-version = "11.1.0"
+version = "12.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -9397,8 +9397,3 @@ dependencies = [
  "cc",
  "libc",
 ]
-
-[[patch.unused]]
-name = "librocksdb-sys"
-version = "6.11.4"
-source = "git+https://github.com/hdevalence/rust-rocksdb?branch=master#33cd4281570b229b628d6d827fa0053cff57000a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,6 @@ orml-tokens = {git = 'https://github.com/open-web3-stack/open-runtime-module-lib
 orml-traits = {git = 'https://github.com/open-web3-stack/open-runtime-module-library', branch = 'master'}
 orml-utilities = {git = 'https://github.com/open-web3-stack/open-runtime-module-library', branch = 'master'}
 
-librocksdb-sys = {git = "https://github.com/hdevalence/rust-rocksdb", branch = "master"}
-
 [profile.release]
 panic = 'unwind'
 


### PR DESCRIPTION
Libsrock-db was updated. The patch can be now discarded.