### PR TITLE
refactor(build-script): allow to specify runtime

### DIFF
--- a/node/build.rs
+++ b/node/build.rs
@@ -1,6 +1,6 @@
 use hydra_dx_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
 
 fn main() {
-	generate_cargo_keys().expect("Failed to generate version metadata");
+	generate_cargo_keys("hydra-dx-runtime").expect("Failed to generate version metadata");
 	rerun_if_git_head_changed();
 }

--- a/utils/build-script-utils/src/version.rs
+++ b/utils/build-script-utils/src/version.rs
@@ -40,7 +40,7 @@ fn get_platform() -> String {
 
 fn get_release_version() -> String {
 	let output = Command::new("git")
-		.args(&["describe", "--tags", "--abbrev=0"])
+		.args(&["describe", "--tags", "--abbrev=0", "--always"])
 		.output();
 
 	let version = match output {
@@ -76,12 +76,12 @@ fn parse_dependencies(lock_toml_buf: &str) -> Vec<(String, String)> {
 	deps
 }
 
-fn get_version(impl_commit: &str) -> io::Result<String> {
+fn get_version(impl_commit: &str, runtime: &str) -> io::Result<String> {
 	let commit_dash = if impl_commit.is_empty() { "" } else { "-" };
 	let deps = get_build_deps(env::var("CARGO_MANIFEST_DIR").unwrap().as_ref())?;
-	let runtime_dependency: Vec<(String, String)> = deps.into_iter().filter(|(dep,_)| dep.eq("hydra-dx-runtime")).collect();
+	let runtime_dependency: Vec<(String, String)> = deps.into_iter().filter(|(dep, _)| dep.eq(runtime)).collect();
 	let runtime_version = if runtime_dependency.is_empty() {
-		println!("cargo:warning=hydra-dx-runtime not found in dependencies");
+		println!("cargo:warning={} found in dependencies", runtime);
 		"unknown".to_string()
 	} else {
 		runtime_dependency[0].1.clone()

--- a/utils/build-script-utils/src/version.rs
+++ b/utils/build-script-utils/src/version.rs
@@ -2,7 +2,7 @@ use platforms::*;
 use std::{borrow::Cow, process::Command, path, io, fs, env};
 
 /// Generate the `cargo:` key output
-pub fn generate_cargo_keys() -> io::Result<()> {
+pub fn generate_cargo_keys(runtime: &str) -> io::Result<()> {
 	let output = Command::new("git")
 		.args(&["rev-parse", "--short", "HEAD"])
 		.output();
@@ -22,7 +22,7 @@ pub fn generate_cargo_keys() -> io::Result<()> {
 		},
 	};
 
-	println!("cargo:rustc-env=SUBSTRATE_CLI_IMPL_VERSION={}", get_version(&commit).unwrap());
+	println!("cargo:rustc-env=SUBSTRATE_CLI_IMPL_VERSION={}", get_version(&commit, runtime).unwrap());
 	Ok(())
 }
 


### PR DESCRIPTION
## Description
In build-script-utils , there is runtime name hardcoded to "hydra-dx-runtime". That means, it is only possible to use it with that given runtime.

This PR is making this value configurable so it is possible to use with different runtimes.

In Basilisk, for example - we don't need to have the same utils but could use the crate from hydradx-node repo.

## Related Issue
Nope.

## Motivation and Context
To be able to use it in Basilisk or even with testing runtime ( when support for this is merged ) - it would be great to have a possibility to specify runtime name for which cargo keys should be generated. 

## How Has This Been Tested?
Locally.