### PR TITLE
feat: add fee to AMMTransfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "hydra-dx-runtime"
-version = "15.0.1"
+version = "15.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-exchange"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-xyk"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5247,7 +5247,7 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/pallets/exchange/Cargo.toml
+++ b/pallets/exchange/Cargo.toml
@@ -6,7 +6,7 @@ homepage = 'https://github.com/galacticcouncil/hydradx-node'
 license = 'Apache 2.0'
 name = 'pallet-exchange'
 repository = 'https://github.com/galacticcouncil/hydradx-node'
-version = '3.2.1'
+version = '3.3.0'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/pallets/exchange/benchmarking/src/lib.rs
+++ b/pallets/exchange/benchmarking/src/lib.rs
@@ -288,7 +288,7 @@ benchmarks! {
 	}: { xykpool::Pallet::<T>::sell(RawOrigin::Signed(seller.clone()).into(), asset_a, asset_b, 1_000_000_000, min_bought, false)?; }
 	verify {
 		assert_eq!(<T as xykpool::Config>::Currency::free_balance(asset_a, &seller), 999_999_000_000_000);
-		assert_eq!(<T as xykpool::Config>::Currency::free_balance(asset_b, &seller), 1000000907437716);
+		assert_eq!(<T as xykpool::Config>::Currency::free_balance(asset_b, &seller), 1000000907272729);
 	}
 
 	on_finalize_for_one_sell_extrinsic {
@@ -317,7 +317,7 @@ benchmarks! {
 	verify {
 		assert_eq!(pallet_exchange::Pallet::<T>::get_intentions_count((asset_a, asset_b)), 0);
 		assert_eq!(<T as xykpool::Config>::Currency::free_balance(asset_a, &seller), 999_999_000_000_000);
-		assert_eq!(<T as xykpool::Config>::Currency::free_balance(asset_b, &seller), 1000000907437716);
+		assert_eq!(<T as xykpool::Config>::Currency::free_balance(asset_b, &seller), 1000000907272729);
 	}
 
 	buy_extrinsic {

--- a/pallets/exchange/src/lib.rs
+++ b/pallets/exchange/src/lib.rs
@@ -411,7 +411,7 @@ impl<T: Config> Pallet<T> {
 	fn execute_amm_transfer(
 		amm_tranfer_type: IntentionType,
 		intention_id: IntentionId<T>,
-		transfer: &AMMTransfer<T::AccountId, AssetPair, Balance>,
+		transfer: &AMMTransfer<T::AccountId, AssetId, AssetPair, Balance>,
 	) -> dispatch::DispatchResult {
 		match amm_tranfer_type {
 			IntentionType::SELL => {
@@ -421,7 +421,7 @@ impl<T: Config> Pallet<T> {
 					transfer.origin.clone(),
 					IntentionType::SELL,
 					intention_id,
-					transfer.amount,
+					transfer.amount + transfer.fee.1,
 					transfer.amount_out,
 				));
 			}
@@ -433,7 +433,7 @@ impl<T: Config> Pallet<T> {
 					IntentionType::BUY,
 					intention_id,
 					transfer.amount,
-					transfer.amount_out,
+					transfer.amount_out + transfer.fee.1,
 				));
 			}
 		};

--- a/pallets/exchange/src/tests.rs
+++ b/pallets/exchange/src/tests.rs
@@ -204,7 +204,7 @@ fn sell_test_pool_finalization_states() {
 				4000000000,
 			)
 			.into(),
-			xyk::Event::SellExecuted(user_2, 3000, 2000, 1000000000000, 1976336046259).into(),
+			xyk::Event::SellExecuted(user_2, 3000, 2000, 998000000000, 1976336046259, 3000, 2000000000).into(),
 			Event::IntentionResolvedAMMTrade(
 				user_2,
 				IntentionType::SELL,
@@ -334,7 +334,7 @@ fn sell_test_standard() {
 				4000000000,
 			)
 			.into(),
-			xyk::Event::SellExecuted(user_2, 3000, 2000, 1000000000000, 1976336046259).into(),
+			xyk::Event::SellExecuted(user_2, 3000, 2000, 998000000000, 1976336046259, 3000, 2000000000).into(),
 			Event::IntentionResolvedAMMTrade(
 				user_2,
 				IntentionType::SELL,
@@ -427,7 +427,7 @@ fn sell_test_inverse_standard() {
 				user_3_sell_intention_id,
 			)
 			.into(),
-			xyk::Event::SellExecuted(3, 2000, 3000, 2000000000000, 988138378978).into(),
+			xyk::Event::SellExecuted(3, 2000, 3000, 1996000000000, 988138378978, 2000, 4000000000).into(),
 			Event::IntentionResolvedAMMTrade(
 				user_3,
 				IntentionType::SELL,
@@ -646,7 +646,16 @@ fn sell_test_single_eth_sells() {
 				user_3_sell_intention_id,
 			)
 			.into(),
-			xyk::Event::SellExecuted(user_3, asset_a, asset_b, 2000000000000, 3913878975647).into(),
+			xyk::Event::SellExecuted(
+				user_3,
+				asset_a,
+				asset_b,
+				1996000000000,
+				3913878975647,
+				asset_a,
+				4000000000,
+			)
+			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_3,
 				IntentionType::SELL,
@@ -655,7 +664,16 @@ fn sell_test_single_eth_sells() {
 				3913878975647,
 			)
 			.into(),
-			xyk::Event::SellExecuted(user_2, asset_a, asset_b, 1000000000000, 1899978143094).into(),
+			xyk::Event::SellExecuted(
+				user_2,
+				asset_a,
+				asset_b,
+				998000000000,
+				1899978143094,
+				asset_a,
+				2000000000,
+			)
+			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_2,
 				IntentionType::SELL,
@@ -743,7 +761,16 @@ fn sell_test_single_dot_sells() {
 				user_3_sell_intention_id,
 			)
 			.into(),
-			xyk::Event::SellExecuted(user_3, asset_b, asset_a, 2000000000000, 988138378978).into(),
+			xyk::Event::SellExecuted(
+				user_3,
+				asset_b,
+				asset_a,
+				1996000000000,
+				988138378978,
+				asset_b,
+				4000000000,
+			)
+			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_3,
 				IntentionType::SELL,
@@ -752,7 +779,16 @@ fn sell_test_single_dot_sells() {
 				988138378978,
 			)
 			.into(),
-			xyk::Event::SellExecuted(user_2, asset_b, asset_a, 1000000000000, 486772470162).into(),
+			xyk::Event::SellExecuted(
+				user_2,
+				asset_b,
+				asset_a,
+				998000000000,
+				486772470162,
+				asset_b,
+				2000000000,
+			)
+			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_2,
 				IntentionType::SELL,
@@ -837,7 +873,16 @@ fn sell_trade_limits_respected_for_matched_intention() {
 				},
 			)
 			.into(),
-			xyk::Event::SellExecuted(user_2, asset_a, asset_b, 1000000000000, 1976276757956).into(),
+			xyk::Event::SellExecuted(
+				user_2,
+				asset_a,
+				asset_b,
+				998000000000,
+				1976276757956,
+				asset_a,
+				2000000000,
+			)
+			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_2,
 				IntentionType::SELL,
@@ -1035,7 +1080,16 @@ fn sell_test_single_multiple_sells() {
 				1000000000,
 			)
 			.into(),
-			xyk::Event::SellExecuted(user_4, asset_a, asset_b, 500000000000, 993044854829).into(),
+			xyk::Event::SellExecuted(
+				user_4,
+				asset_a,
+				asset_b,
+				499000000000,
+				993044854829,
+				asset_a,
+				1000000000,
+			)
+			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_4,
 				IntentionType::SELL,
@@ -1044,7 +1098,16 @@ fn sell_test_single_multiple_sells() {
 				993044854829,
 			)
 			.into(),
-			xyk::Event::SellExecuted(user_5, asset_b, asset_a, 1000000000000, 501482500933).into(),
+			xyk::Event::SellExecuted(
+				user_5,
+				asset_b,
+				asset_a,
+				998000000000,
+				501482500933,
+				asset_b,
+				2000000000,
+			)
+			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_5,
 				IntentionType::SELL,
@@ -1204,7 +1267,16 @@ fn sell_test_group_sells() {
 				3000000000,
 			)
 			.into(),
-			xyk::Event::SellExecuted(user_4, asset_a, asset_b, 6000000000000, 11299443450697).into(),
+			xyk::Event::SellExecuted(
+				user_4,
+				asset_a,
+				asset_b,
+				5988000000000,
+				11299443450697,
+				asset_a,
+				12000000000,
+			)
+			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_4,
 				IntentionType::SELL,
@@ -1394,7 +1466,16 @@ fn sell_test_mixed_buy_sells() {
 				3000000000,
 			)
 			.into(),
-			xyk::Event::SellExecuted(user_4, asset_a, asset_b, 8500000000000, 15639353446528).into(),
+			xyk::Event::SellExecuted(
+				user_4,
+				asset_a,
+				asset_b,
+				8483000000000,
+				15639353446528,
+				asset_a,
+				17000000000,
+			)
+			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_4,
 				IntentionType::SELL,
@@ -1403,7 +1484,16 @@ fn sell_test_mixed_buy_sells() {
 				15639353446528,
 			)
 			.into(),
-			xyk::Event::BuyExecuted(user_2, asset_b, asset_a, 5000000000000, 3030663952554).into(),
+			xyk::Event::BuyExecuted(
+				user_2,
+				asset_b,
+				asset_a,
+				5000000000000,
+				3024614723108,
+				asset_a,
+				6049229446,
+			)
+			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_2,
 				IntentionType::BUY,
@@ -1538,7 +1628,16 @@ fn discount_tests_no_discount() {
 				3000000000,
 			)
 			.into(),
-			xyk::Event::SellExecuted(user_4, asset_a, asset_b, 8500000000000, 15639353446528).into(),
+			xyk::Event::SellExecuted(
+				user_4,
+				asset_a,
+				asset_b,
+				8483000000000,
+				15639353446528,
+				asset_a,
+				17000000000,
+			)
+			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_4,
 				IntentionType::SELL,
@@ -1547,7 +1646,16 @@ fn discount_tests_no_discount() {
 				15639353446528,
 			)
 			.into(),
-			xyk::Event::BuyExecuted(user_2, asset_b, asset_a, 5000000000000, 3030663952554).into(),
+			xyk::Event::BuyExecuted(
+				user_2,
+				asset_b,
+				asset_a,
+				5000000000000,
+				3024614723108,
+				asset_a,
+				6049229446,
+			)
+			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_2,
 				IntentionType::BUY,
@@ -1688,7 +1796,16 @@ fn discount_tests_with_discount() {
 				3000000000,
 			)
 			.into(),
-			xyk::Event::SellExecuted(user_4, asset_a, asset_b, 8500000000000, 15658130468064).into(),
+			xyk::Event::SellExecuted(
+				user_4,
+				asset_a,
+				asset_b,
+				8494050000000,
+				15658130468064,
+				asset_a,
+				5950000000,
+			)
+			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_4,
 				IntentionType::SELL,
@@ -1697,7 +1814,16 @@ fn discount_tests_with_discount() {
 				15658130468064,
 			)
 			.into(),
-			xyk::Event::BuyExecuted(user_2, asset_b, asset_a, 5000000000000, 3027048840428).into(),
+			xyk::Event::BuyExecuted(
+				user_2,
+				asset_b,
+				asset_a,
+				5000000000000,
+				3024931388457,
+				asset_a,
+				2117451971,
+			)
+			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_2,
 				IntentionType::BUY,
@@ -1910,7 +2036,16 @@ fn buy_test_group_buys() {
 				user_4_sell_intention_id,
 			)
 			.into(),
-			xyk::Event::BuyExecuted(user_4, asset_a, asset_b, 7500000000000, 16248648648649).into(),
+			xyk::Event::BuyExecuted(
+				user_4,
+				asset_a,
+				asset_b,
+				7500000000000,
+				16216216216217,
+				asset_b,
+				32432432432,
+			)
+			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_4,
 				IntentionType::BUY,
@@ -1944,7 +2079,16 @@ fn buy_test_group_buys() {
 				10000000000,
 			)
 			.into(),
-			xyk::Event::BuyExecuted(user_3, asset_b, asset_a, 3000000000000, 1303909744163).into(),
+			xyk::Event::BuyExecuted(
+				user_3,
+				asset_b,
+				asset_a,
+				3000000000000,
+				1301307129904,
+				asset_a,
+				2602614259,
+			)
+			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_3,
 				IntentionType::BUY,
@@ -2188,7 +2332,7 @@ fn simple_sell_sell() {
 			.into(),
 			Event::IntentionResolvedDirectTradeFees(user_2, user_2_sell_intention_id, pair_account, asset_b, 2).into(),
 			Event::IntentionResolvedDirectTradeFees(user_3, user_3_sell_intention_id, pair_account, asset_a, 1).into(),
-			xyk::Event::SellExecuted(2, 3000, 2000, 1500, 2994).into(),
+			xyk::Event::SellExecuted(2, 3000, 2000, 1497, 2994, 3000, 3).into(),
 			Event::IntentionResolvedAMMTrade(user_2, IntentionType::SELL, user_2_sell_intention_id, 1500, 2994).into(),
 		]);
 	});
@@ -2264,7 +2408,7 @@ fn simple_buy_buy() {
 				user_3_sell_intention_id,
 			)
 			.into(),
-			xyk::Event::BuyExecuted(2, 3000, 2000, 1500, 3007).into(),
+			xyk::Event::BuyExecuted(2, 3000, 2000, 1500, 3001, 2000, 6).into(),
 			Event::IntentionResolvedAMMTrade(user_2, IntentionType::BUY, user_2_sell_intention_id, 1500, 3007).into(),
 			Event::IntentionResolvedDirectTrade(
 				user_3,
@@ -2363,7 +2507,7 @@ fn simple_sell_buy() {
 			.into(),
 			Event::IntentionResolvedDirectTradeFees(user_2, user_2_sell_intention_id, pair_account, asset_b, 2).into(),
 			Event::IntentionResolvedDirectTradeFees(user_3, user_3_sell_intention_id, pair_account, asset_b, 4).into(),
-			xyk::Event::SellExecuted(2, 3000, 2000, 1000, 1996).into(),
+			xyk::Event::SellExecuted(2, 3000, 2000, 998, 1996, 3000, 2).into(),
 			Event::IntentionResolvedAMMTrade(user_2, IntentionType::SELL, user_2_sell_intention_id, 1000, 1996).into(),
 		]);
 	});
@@ -2440,7 +2584,7 @@ fn simple_buy_sell() {
 				user_3_sell_intention_id,
 			)
 			.into(),
-			xyk::Event::BuyExecuted(user_2, 3000, 2000, 1000, 2005).into(),
+			xyk::Event::BuyExecuted(user_2, 3000, 2000, 1000, 2001, 2000, 4).into(),
 			Event::IntentionResolvedAMMTrade(user_2, IntentionType::BUY, user_2_sell_intention_id, 1000, 2005).into(),
 			Event::IntentionResolvedDirectTrade(
 				user_3,
@@ -2509,7 +2653,7 @@ fn single_sell_intention_test() {
 				user_2_sell_intention_id,
 			)
 			.into(),
-			xyk::Event::SellExecuted(2, 3000, 2000, 2000000000000, 3913878975647).into(),
+			xyk::Event::SellExecuted(2, 3000, 2000, 1996000000000, 3913878975647, 3000, 4000000000).into(),
 			Event::IntentionResolvedAMMTrade(
 				user_2,
 				IntentionType::SELL,
@@ -2575,7 +2719,7 @@ fn single_buy_intention_test() {
 				user_2_sell_intention_id,
 			)
 			.into(),
-			xyk::Event::BuyExecuted(2, 3000, 2000, 2000000000000, 4089795918368).into(),
+			xyk::Event::BuyExecuted(2, 3000, 2000, 2000000000000, 4081632653062, 2000, 8163265306).into(),
 			Event::IntentionResolvedAMMTrade(
 				user_2,
 				IntentionType::BUY,

--- a/pallets/exchange/src/tests.rs
+++ b/pallets/exchange/src/tests.rs
@@ -204,20 +204,20 @@ fn sell_test_pool_finalization_states() {
 				4000000000,
 			)
 			.into(),
-			xyk::Event::SellExecuted(user_2, 3000, 2000, 998000000000, 1976336046259, 3000, 2000000000).into(),
+			xyk::Event::SellExecuted(user_2, 3000, 2000, 1000000000000, 1976296910892, 2000, 3960514851).into(),
 			Event::IntentionResolvedAMMTrade(
 				user_2,
 				IntentionType::SELL,
 				user_2_sell_intention_id,
-				1000000000000,
-				1976336046259,
+				1003960514851,
+				1976296910892,
 			)
 			.into(),
 		]);
 
 		// Check final account balances
 		assert_eq!(Currency::free_balance(asset_a, &user_2), 998_000_000_000_000);
-		assert_eq!(Currency::free_balance(asset_b, &user_2), 1003974336046259);
+		assert_eq!(Currency::free_balance(asset_b, &user_2), 1003974296910892);
 
 		assert_eq!(Currency::free_balance(asset_a, &user_3), 1001000000000000);
 		assert_eq!(Currency::free_balance(asset_b, &user_3), 997996000000000);
@@ -225,7 +225,7 @@ fn sell_test_pool_finalization_states() {
 		// Check final pool balances
 		// TODO: CHECK IF RIGHT
 		assert_eq!(Currency::free_balance(asset_a, &pair_account), 101000000000000);
-		assert_eq!(Currency::free_balance(asset_b, &pair_account), 198029663953741);
+		assert_eq!(Currency::free_balance(asset_b, &pair_account), 198029703089108);
 
 		assert_eq!(Exchange::get_intentions_count((asset_b, asset_a)), 0);
 	});
@@ -277,14 +277,14 @@ fn sell_test_standard() {
 
 		// Check final account balances -> SEEMS LEGIT
 		assert_eq!(Currency::free_balance(asset_a, &user_2), 998_000_000_000_000);
-		assert_eq!(Currency::free_balance(asset_b, &user_2), 1003974336046259);
+		assert_eq!(Currency::free_balance(asset_b, &user_2), 1003974296910892);
 
 		assert_eq!(Currency::free_balance(asset_a, &user_3), 1001000000000000);
 		assert_eq!(Currency::free_balance(asset_b, &user_3), 997996000000000);
 
 		// Check final pool balances -> SEEMS LEGIT
 		assert_eq!(Currency::free_balance(asset_a, &pair_account), 101000000000000);
-		assert_eq!(Currency::free_balance(asset_b, &pair_account), 198029663953741);
+		assert_eq!(Currency::free_balance(asset_b, &pair_account), 198029703089108);
 
 		// TODO: check if final transferred balances add up to initial balance
 		// No tokens should be created or lost
@@ -334,13 +334,13 @@ fn sell_test_standard() {
 				4000000000,
 			)
 			.into(),
-			xyk::Event::SellExecuted(user_2, 3000, 2000, 998000000000, 1976336046259, 3000, 2000000000).into(),
+			xyk::Event::SellExecuted(user_2, 3000, 2000, 1000000000000, 1976296910892, 2000, 3960514851).into(),
 			Event::IntentionResolvedAMMTrade(
 				user_2,
 				IntentionType::SELL,
 				user_2_sell_intention_id,
-				1000000000000,
-				1976336046259,
+				1003960514851,
+				1976296910892,
 			)
 			.into(),
 		]);
@@ -396,11 +396,11 @@ fn sell_test_inverse_standard() {
 		assert_eq!(Currency::free_balance(asset_a, &user_2), 999_000_000_000_000);
 		assert_eq!(Currency::free_balance(asset_b, &user_2), 1001996000000000);
 
-		assert_eq!(Currency::free_balance(asset_a, &user_3), 1_001_986_138_378_978);
+		assert_eq!(Currency::free_balance(asset_a, &user_3), 1_001_986_118_811_882);
 		assert_eq!(Currency::free_balance(asset_b, &user_3), 996_000_000_000_000);
 
 		// Check final pool balances  -> SEEMS LEGIT
-		assert_eq!(Currency::free_balance(asset_a, &pair_account), 99_013_861_621_022);
+		assert_eq!(Currency::free_balance(asset_a, &pair_account), 99_013_881_188_118);
 		assert_eq!(Currency::free_balance(asset_b, &pair_account), 202004000000000);
 
 		// TODO: check if final transferred balances add up to initial balance
@@ -427,13 +427,13 @@ fn sell_test_inverse_standard() {
 				user_3_sell_intention_id,
 			)
 			.into(),
-			xyk::Event::SellExecuted(3, 2000, 3000, 1996000000000, 988138378978, 2000, 4000000000).into(),
+			xyk::Event::SellExecuted(3, 2000, 3000, 2000000000000, 988118811882, 3000, 1980198019).into(),
 			Event::IntentionResolvedAMMTrade(
 				user_3,
 				IntentionType::SELL,
 				user_3_sell_intention_id,
-				2000000000000,
-				988138378978,
+				2001980198019,
+				988118811882,
 			)
 			.into(),
 			Event::IntentionResolvedDirectTrade(
@@ -616,14 +616,14 @@ fn sell_test_single_eth_sells() {
 
 		// Check final account balances -> SEEMS LEGIT
 		assert_eq!(Currency::free_balance(asset_a, &user_2), 999_000_000_000_000);
-		assert_eq!(Currency::free_balance(asset_b, &user_2), 1_001_899_978_143_094);
+		assert_eq!(Currency::free_balance(asset_b, &user_2), 1_001_899_942_737_485);
 
 		assert_eq!(Currency::free_balance(asset_a, &user_3), 998_000_000_000_000);
-		assert_eq!(Currency::free_balance(asset_b, &user_3), 1003913878975647);
+		assert_eq!(Currency::free_balance(asset_b, &user_3), 1003913725490197);
 
 		// Check final pool balances -> SEEMS LEGIT
 		assert_eq!(Currency::free_balance(asset_a, &pair_account), 103_000_000_000_000);
-		assert_eq!(Currency::free_balance(asset_b, &pair_account), 194_186_142_881_259);
+		assert_eq!(Currency::free_balance(asset_b, &pair_account), 194_186_331_772_318);
 
 		assert_eq!(Exchange::get_intentions_count((asset_b, asset_a)), 0);
 
@@ -650,36 +650,36 @@ fn sell_test_single_eth_sells() {
 				user_3,
 				asset_a,
 				asset_b,
-				1996000000000,
-				3913878975647,
-				asset_a,
-				4000000000,
+				2000000000000,
+				3913725490197,
+				asset_b,
+				7843137254,
 			)
 			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_3,
 				IntentionType::SELL,
 				user_3_sell_intention_id,
-				2000000000000,
-				3913878975647,
+				2007843137254,
+				3913725490197,
 			)
 			.into(),
 			xyk::Event::SellExecuted(
 				user_2,
 				asset_a,
 				asset_b,
-				998000000000,
-				1899978143094,
-				asset_a,
-				2000000000,
+				1000000000000,
+				1899942737485,
+				asset_b,
+				3807500475,
 			)
 			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_2,
 				IntentionType::SELL,
 				user_2_sell_intention_id,
-				1000000000000,
-				1899978143094,
+				1003807500475,
+				1899942737485,
 			)
 			.into(),
 		]);
@@ -731,14 +731,14 @@ fn sell_test_single_dot_sells() {
 		<Exchange as OnFinalize<u64>>::on_finalize(9);
 
 		// Check final account balances -> SEEMS LEGIT
-		assert_eq!(Currency::free_balance(asset_a, &user_2), 1000486772470162);
+		assert_eq!(Currency::free_balance(asset_a, &user_2), 1000486767770571);
 		assert_eq!(Currency::free_balance(asset_b, &user_2), 999_000_000_000_000);
 
-		assert_eq!(Currency::free_balance(asset_a, &user_3), 1000988138378978);
+		assert_eq!(Currency::free_balance(asset_a, &user_3), 1000988118811882);
 		assert_eq!(Currency::free_balance(asset_b, &user_3), 998_000_000_000_000);
 
 		// Check final pool balances -> SEEMS LEGIT
-		assert_eq!(Currency::free_balance(asset_a, &pair_account), 98525089150860);
+		assert_eq!(Currency::free_balance(asset_a, &pair_account), 98525113417547);
 		assert_eq!(Currency::free_balance(asset_b, &pair_account), 203_000_000_000_000);
 
 		assert_eq!(Exchange::get_intentions_count((asset_b, asset_a)), 0);
@@ -765,36 +765,36 @@ fn sell_test_single_dot_sells() {
 				user_3,
 				asset_b,
 				asset_a,
-				1996000000000,
-				988138378978,
-				asset_b,
-				4000000000,
+				2000000000000,
+				988118811882,
+				asset_a,
+				1980198019,
 			)
 			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_3,
 				IntentionType::SELL,
 				user_3_sell_intention_id,
-				2000000000000,
-				988138378978,
+				2001980198019,
+				988118811882,
 			)
 			.into(),
 			xyk::Event::SellExecuted(
 				user_2,
 				asset_b,
 				asset_a,
-				998000000000,
-				486772470162,
-				asset_b,
-				2000000000,
+				1000000000000,
+				486767770571,
+				asset_a,
+				975486514,
 			)
 			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_2,
 				IntentionType::SELL,
 				user_2_sell_intention_id,
-				1000000000000,
-				486772470162,
+				1000975486514,
+				486767770571,
 			)
 			.into(),
 		]);
@@ -877,18 +877,18 @@ fn sell_trade_limits_respected_for_matched_intention() {
 				user_2,
 				asset_a,
 				asset_b,
-				998000000000,
-				1976276757956,
-				asset_a,
-				2000000000,
+				1000000000000,
+				1976237623763,
+				asset_b,
+				3960396039,
 			)
 			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_2,
 				IntentionType::SELL,
 				user_2_sell_intention_id,
-				1000000000000,
-				1976276757956,
+				1003960396039,
+				1976237623763,
 			)
 			.into(),
 		]);
@@ -976,11 +976,11 @@ fn sell_test_single_multiple_sells() {
 		assert_eq!(Currency::free_balance(asset_b, &user_3), 999000000000000);
 
 		assert_eq!(Currency::free_balance(asset_a, &user_4), 999000000000000);
-		assert_eq!(Currency::free_balance(asset_b, &user_4), 1001991044854829);
+		assert_eq!(Currency::free_balance(asset_b, &user_4), 1001991034974081);
 
 		// Check final pool balances
-		assert_eq!(Currency::free_balance(asset_a, &pair_account), 100001517499067);
-		assert_eq!(Currency::free_balance(asset_b, &pair_account), 200012955145171);
+		assert_eq!(Currency::free_balance(asset_a, &pair_account), 100001522538341);
+		assert_eq!(Currency::free_balance(asset_b, &pair_account), 200012965025919);
 
 		assert_eq!(Exchange::get_intentions_count((asset_b, asset_a)), 0);
 
@@ -1084,36 +1084,36 @@ fn sell_test_single_multiple_sells() {
 				user_4,
 				asset_a,
 				asset_b,
-				499000000000,
-				993044854829,
-				asset_a,
-				1000000000,
+				500000000000,
+				993034974081,
+				asset_b,
+				1990050048,
 			)
 			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_4,
 				IntentionType::SELL,
 				user_4_sell_intention_id,
-				5_000_000_000_00,
-				993044854829,
+				501990050048,
+				993034974081,
 			)
 			.into(),
 			xyk::Event::SellExecuted(
 				user_5,
 				asset_b,
 				asset_a,
-				998000000000,
-				501482500933,
-				asset_b,
-				2000000000,
+				1000000000000,
+				501477461659,
+				asset_a,
+				1004964853,
 			)
 			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_5,
 				IntentionType::SELL,
 				user_5_sell_intention_id,
-				1000000000000,
-				501482500933,
+				1001004964853,
+				501477461659,
 			)
 			.into(),
 		]);
@@ -1181,11 +1181,11 @@ fn sell_test_group_sells() {
 		assert_eq!(Currency::free_balance(asset_b, &user_3), 997000000000000);
 
 		assert_eq!(Currency::free_balance(asset_a, &user_4), 990000000000000);
-		assert_eq!(Currency::free_balance(asset_b, &user_4), 1019283443450697);
+		assert_eq!(Currency::free_balance(asset_b, &user_4), 1019282164364955);
 
 		// Check final pool balances
 		assert_eq!(Currency::free_balance(asset_a, &pair_account), 106008000000000);
-		assert_eq!(Currency::free_balance(asset_b, &pair_account), 188716556549303);
+		assert_eq!(Currency::free_balance(asset_b, &pair_account), 188717835635045);
 
 		assert_eq!(Exchange::get_intentions_count((asset_b, asset_a)), 0);
 
@@ -1271,18 +1271,18 @@ fn sell_test_group_sells() {
 				user_4,
 				asset_a,
 				asset_b,
-				5988000000000,
-				11299443450697,
-				asset_a,
-				12000000000,
+				6000000000000,
+				11298164364955,
+				asset_b,
+				22641611953,
 			)
 			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_4,
 				IntentionType::SELL,
 				user_4_sell_intention_id,
-				6000000000000,
-				11299443450697,
+				6022641611953,
+				11298164364955,
 			)
 			.into(),
 		]);
@@ -1398,18 +1398,18 @@ fn sell_test_mixed_buy_sells() {
 		<Exchange as OnFinalize<u64>>::on_finalize(9);
 
 		// Check final account balances
-		assert_eq!(Currency::free_balance(asset_a, &user_2), 996969336047446);
+		assert_eq!(Currency::free_balance(asset_a, &user_2), 996969377448952);
 		assert_eq!(Currency::free_balance(asset_b, &user_2), 1005000000000000);
 
 		assert_eq!(Currency::free_balance(asset_a, &user_3), 1001497000000000);
 		assert_eq!(Currency::free_balance(asset_b, &user_3), 997000000000000);
 
 		assert_eq!(Currency::free_balance(asset_a, &user_4), 990000000000000);
-		assert_eq!(Currency::free_balance(asset_b, &user_4), 1018633353446528);
+		assert_eq!(Currency::free_balance(asset_b, &user_4), 1018630903108671);
 
 		// Check final pool balances
-		assert_eq!(Currency::free_balance(asset_a, &pair_account), 111533663952554);
-		assert_eq!(Currency::free_balance(asset_b, &pair_account), 179366646553472);
+		assert_eq!(Currency::free_balance(asset_a, &pair_account), 111533622551048);
+		assert_eq!(Currency::free_balance(asset_b, &pair_account), 179369096891329);
 
 		assert_eq!(Exchange::get_intentions_count((asset_b, asset_a)), 0);
 
@@ -1470,18 +1470,18 @@ fn sell_test_mixed_buy_sells() {
 				user_4,
 				asset_a,
 				asset_b,
-				8483000000000,
-				15639353446528,
-				asset_a,
-				17000000000,
+				8500000000000,
+				15636903108671,
+				asset_b,
+				31336479175,
 			)
 			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_4,
 				IntentionType::SELL,
 				user_4_sell_intention_id,
-				8500000000000,
-				15639353446528,
+				8531336479175,
+				15636903108671,
 			)
 			.into(),
 			xyk::Event::BuyExecuted(
@@ -1489,9 +1489,9 @@ fn sell_test_mixed_buy_sells() {
 				asset_b,
 				asset_a,
 				5000000000000,
-				3024614723108,
+				3024573404240,
 				asset_a,
-				6049229446,
+				6049146808,
 			)
 			.into(),
 			Event::IntentionResolvedAMMTrade(
@@ -1499,7 +1499,7 @@ fn sell_test_mixed_buy_sells() {
 				IntentionType::BUY,
 				user_2_sell_intention_id,
 				5000000000000,
-				3030663952554,
+				3030622551048,
 			)
 			.into(),
 		]);
@@ -1560,18 +1560,18 @@ fn discount_tests_no_discount() {
 		<Exchange as OnFinalize<u64>>::on_finalize(9);
 
 		// Check final account balances
-		assert_eq!(Currency::free_balance(asset_a, &user_2), 996969336047446);
+		assert_eq!(Currency::free_balance(asset_a, &user_2), 996969377448952);
 		assert_eq!(Currency::free_balance(asset_b, &user_2), 1005000000000000);
 
 		assert_eq!(Currency::free_balance(asset_a, &user_3), 1001497000000000);
 		assert_eq!(Currency::free_balance(asset_b, &user_3), 997000000000000);
 
 		assert_eq!(Currency::free_balance(asset_a, &user_4), 990000000000000);
-		assert_eq!(Currency::free_balance(asset_b, &user_4), 1018633353446528);
+		assert_eq!(Currency::free_balance(asset_b, &user_4), 1018630903108671);
 
 		// Check final pool balances
-		assert_eq!(Currency::free_balance(asset_a, &pair_account), 111533663952554);
-		assert_eq!(Currency::free_balance(asset_b, &pair_account), 179366646553472);
+		assert_eq!(Currency::free_balance(asset_a, &pair_account), 111533622551048);
+		assert_eq!(Currency::free_balance(asset_b, &pair_account), 179369096891329);
 
 		assert_eq!(Exchange::get_intentions_count((asset_b, asset_a)), 0);
 
@@ -1632,18 +1632,18 @@ fn discount_tests_no_discount() {
 				user_4,
 				asset_a,
 				asset_b,
-				8483000000000,
-				15639353446528,
-				asset_a,
-				17000000000,
+				8500000000000,
+				15636903108671,
+				asset_b,
+				31336479175,
 			)
 			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_4,
 				IntentionType::SELL,
 				user_4_sell_intention_id,
-				8500000000000,
-				15639353446528,
+				8531336479175,
+				15636903108671,
 			)
 			.into(),
 			xyk::Event::BuyExecuted(
@@ -1651,9 +1651,9 @@ fn discount_tests_no_discount() {
 				asset_b,
 				asset_a,
 				5000000000000,
-				3024614723108,
+				3024573404240,
 				asset_a,
-				6049229446,
+				6049146808,
 			)
 			.into(),
 			Event::IntentionResolvedAMMTrade(
@@ -1661,7 +1661,7 @@ fn discount_tests_no_discount() {
 				IntentionType::BUY,
 				user_2_sell_intention_id,
 				5000000000000,
-				3030663952554,
+				3030622551048,
 			)
 			.into(),
 		]);
@@ -1724,21 +1724,21 @@ fn discount_tests_with_discount() {
 		<Exchange as OnFinalize<u64>>::on_finalize(9);
 
 		// Check final account balances
-		assert_eq!(Currency::free_balance(asset_a, &user_2), 896972951159572);
+		assert_eq!(Currency::free_balance(asset_a, &user_2), 896972965651836);
 		assert_eq!(Currency::free_balance(asset_b, &user_2), 1005000000000000);
 
 		assert_eq!(Currency::free_balance(asset_a, &user_3), 1001497000000000);
 		assert_eq!(Currency::free_balance(asset_b, &user_3), 897000000000000);
 
 		assert_eq!(Currency::free_balance(asset_a, &user_4), 990000000000000);
-		assert_eq!(Currency::free_balance(asset_b, &user_4), 1018652130468064);
+		assert_eq!(Currency::free_balance(asset_b, &user_4), 1018651271820135);
 
 		// Check final pool balances
-		assert_eq!(Currency::free_balance(asset_a, &pair_account), 111530048840428);
-		assert_eq!(Currency::free_balance(asset_b, &pair_account), 179347869531936);
+		assert_eq!(Currency::free_balance(asset_a, &pair_account), 111530034348164);
+		assert_eq!(Currency::free_balance(asset_b, &pair_account), 179348728179865);
 
-		assert_eq!(Currency::free_balance(HDX, &user_4), 999988100000000);
-		assert_eq!(Currency::free_balance(HDX, &user_2), 799995765096058);
+		assert_eq!(Currency::free_balance(HDX, &user_4), 999978064464578);
+		assert_eq!(Currency::free_balance(HDX, &user_2), 799995765116332);
 		assert_eq!(Currency::free_balance(HDX, &user_3), 800000000000000);
 
 		assert_eq!(Exchange::get_intentions_count((asset_b, asset_a)), 0);
@@ -1800,18 +1800,18 @@ fn discount_tests_with_discount() {
 				user_4,
 				asset_a,
 				asset_b,
-				8494050000000,
-				15658130468064,
-				asset_a,
-				5950000000,
+				8500000000000,
+				15657271820135,
+				asset_b,
+				10967767711,
 			)
 			.into(),
 			Event::IntentionResolvedAMMTrade(
 				user_4,
 				IntentionType::SELL,
 				user_4_sell_intention_id,
-				8500000000000,
-				15658130468064,
+				8510967767711,
+				15657271820135,
 			)
 			.into(),
 			xyk::Event::BuyExecuted(
@@ -1819,9 +1819,9 @@ fn discount_tests_with_discount() {
 				asset_b,
 				asset_a,
 				5000000000000,
-				3024931388457,
+				3024916906330,
 				asset_a,
-				2117451971,
+				2117441834,
 			)
 			.into(),
 			Event::IntentionResolvedAMMTrade(
@@ -1829,7 +1829,7 @@ fn discount_tests_with_discount() {
 				IntentionType::BUY,
 				user_2_sell_intention_id,
 				5000000000000,
-				3027048840428,
+				3027034348164,
 			)
 			.into(),
 		]);
@@ -2332,8 +2332,8 @@ fn simple_sell_sell() {
 			.into(),
 			Event::IntentionResolvedDirectTradeFees(user_2, user_2_sell_intention_id, pair_account, asset_b, 2).into(),
 			Event::IntentionResolvedDirectTradeFees(user_3, user_3_sell_intention_id, pair_account, asset_a, 1).into(),
-			xyk::Event::SellExecuted(2, 3000, 2000, 1497, 2994, 3000, 3).into(),
-			Event::IntentionResolvedAMMTrade(user_2, IntentionType::SELL, user_2_sell_intention_id, 1500, 2994).into(),
+			xyk::Event::SellExecuted(2, 3000, 2000, 1500, 2994, 2000, 6).into(),
+			Event::IntentionResolvedAMMTrade(user_2, IntentionType::SELL, user_2_sell_intention_id, 1506, 2994).into(),
 		]);
 	});
 }
@@ -2507,8 +2507,8 @@ fn simple_sell_buy() {
 			.into(),
 			Event::IntentionResolvedDirectTradeFees(user_2, user_2_sell_intention_id, pair_account, asset_b, 2).into(),
 			Event::IntentionResolvedDirectTradeFees(user_3, user_3_sell_intention_id, pair_account, asset_b, 4).into(),
-			xyk::Event::SellExecuted(2, 3000, 2000, 998, 1996, 3000, 2).into(),
-			Event::IntentionResolvedAMMTrade(user_2, IntentionType::SELL, user_2_sell_intention_id, 1000, 1996).into(),
+			xyk::Event::SellExecuted(2, 3000, 2000, 1000, 1996, 2000, 4).into(),
+			Event::IntentionResolvedAMMTrade(user_2, IntentionType::SELL, user_2_sell_intention_id, 1004, 1996).into(),
 		]);
 	});
 }
@@ -2635,11 +2635,11 @@ fn single_sell_intention_test() {
 
 		// Check final account balances -> SEEMS LEGIT
 		assert_eq!(Currency::free_balance(asset_a, &user_2), 998_000_000_000_000);
-		assert_eq!(Currency::free_balance(asset_b, &user_2), 1003913878975647);
+		assert_eq!(Currency::free_balance(asset_b, &user_2), 1003913725490197);
 
 		// Check final pool balances -> SEEMS LEGIT
 		assert_eq!(Currency::free_balance(asset_a, &pair_account), 102000000000000);
-		assert_eq!(Currency::free_balance(asset_b, &pair_account), 196086121024353);
+		assert_eq!(Currency::free_balance(asset_b, &pair_account), 196086274509803);
 
 		assert_eq!(Exchange::get_intentions_count((asset_b, asset_a)), 0);
 
@@ -2653,13 +2653,13 @@ fn single_sell_intention_test() {
 				user_2_sell_intention_id,
 			)
 			.into(),
-			xyk::Event::SellExecuted(2, 3000, 2000, 1996000000000, 3913878975647, 3000, 4000000000).into(),
+			xyk::Event::SellExecuted(2, 3000, 2000, 2000000000000, 3913725490197, 2000, 7843137254).into(),
 			Event::IntentionResolvedAMMTrade(
 				user_2,
 				IntentionType::SELL,
 				user_2_sell_intention_id,
-				2000000000000,
-				3913878975647,
+				2007843137254,
+				3913725490197,
 			)
 			.into(),
 		]);

--- a/pallets/xyk/Cargo.toml
+++ b/pallets/xyk/Cargo.toml
@@ -6,7 +6,7 @@ homepage = 'https://github.com/galacticcouncil/hydradx-node'
 license = 'Apache 2.0'
 name = 'pallet-xyk'
 repository = 'https://github.com/galacticcouncil/hydradx-node'
-version = '1.1.1'
+version = '1.2.0'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/pallets/xyk/src/benchmarking.rs
+++ b/pallets/xyk/src/benchmarking.rs
@@ -103,7 +103,7 @@ benchmarks! {
 	}: _(RawOrigin::Signed(caller.clone()), asset_a, asset_b, amount, min_bought, discount)
 	verify{
 		assert_eq!(T::Currency::free_balance(asset_a, &caller), 999999000000000);
-		assert_eq!(T::Currency::free_balance(asset_b, &caller), 1000002991014968);
+		assert_eq!(T::Currency::free_balance(asset_b, &caller), 1000002991008993);
 	}
 
 	buy {

--- a/pallets/xyk/src/tests.rs
+++ b/pallets/xyk/src/tests.rs
@@ -338,14 +338,14 @@ fn sell_test() {
 		));
 
 		assert_eq!(Currency::free_balance(asset_a, &user_1), 999799543555322);
-		assert_eq!(Currency::free_balance(asset_b, &user_1), 401363489802256);
+		assert_eq!(Currency::free_balance(asset_b, &user_1), 401363483591788);
 		assert_eq!(Currency::free_balance(share_token, &user_1), 600000000000000);
 		assert_eq!(Currency::free_balance(asset_a, &pair_account), 200456444678);
-		assert_eq!(Currency::free_balance(asset_b, &pair_account), 598636510197744);
+		assert_eq!(Currency::free_balance(asset_b, &pair_account), 598636516408212);
 
 		expect_events(vec![
 			Event::PoolCreated(ALICE, asset_a, asset_b, 600000000000000).into(),
-			Event::SellExecuted(ALICE, asset_a, asset_b, 455531789, 1363489802256, asset_a, 912889).into(),
+			Event::SellExecuted(ALICE, asset_a, asset_b, 456444678, 1363483591788, asset_b, 2732432047).into(),
 		]);
 	});
 }
@@ -441,13 +441,13 @@ fn work_flow_happy_path_should_work() {
 		assert_eq!(Currency::free_balance(asset_b, &user_1), 986_000_000_000_000);
 
 		assert_eq!(Currency::free_balance(asset_a, &user_2), 999_483_333_333_334);
-		assert_eq!(Currency::free_balance(asset_b, &user_2), 994_490_245_122_554);
+		assert_eq!(Currency::free_balance(asset_b, &user_2), 994_486_999_999_986);
 
 		assert_eq!(Currency::free_balance(share_token, &user_1), 350_000_000_000);
 		assert_eq!(Currency::free_balance(share_token, &user_2), 300_000_000_000);
 
 		assert_eq!(Currency::free_balance(asset_a, &pair_account), 866_666_666_666);
-		assert_eq!(Currency::free_balance(asset_b, &pair_account), 195_09_754_877_446);
+		assert_eq!(Currency::free_balance(asset_b, &pair_account), 19_513_000_000_014);
 
 		// User 1 SELLs
 		assert_ok!(XYK::sell(
@@ -460,13 +460,13 @@ fn work_flow_happy_path_should_work() {
 		));
 
 		assert_eq!(Currency::free_balance(asset_a, &user_1), 999_361_111_111_112);
-		assert_eq!(Currency::free_balance(asset_b, &user_1), 990_870_118_901_375);
+		assert_eq!(Currency::free_balance(asset_b, &user_1), 990_868_493_499_997);
 
 		let user_2_original_balance_1 = Currency::free_balance(asset_a, &user_2);
 		let user_2_original_balance_2 = Currency::free_balance(asset_b, &user_2);
 
 		assert_eq!(user_2_original_balance_1, 999_483_333_333_334);
-		assert_eq!(user_2_original_balance_2, 994_490_245_122_554);
+		assert_eq!(user_2_original_balance_2, 994_486_999_999_986);
 
 		assert_eq!(Currency::free_balance(share_token, &user_1), 350_000_000_000);
 		assert_eq!(Currency::free_balance(share_token, &user_2), 300_000_000_000);
@@ -479,7 +479,7 @@ fn work_flow_happy_path_should_work() {
 		let user_2_remove_1_balance_2 = Currency::free_balance(asset_b, &user_2);
 
 		assert_eq!(user_2_remove_1_balance_1, 999_483_333_351_111);
-		assert_eq!(user_2_remove_1_balance_2, 994_490_245_347_779);
+		assert_eq!(user_2_remove_1_balance_2, 994_487_000_225_286);
 		assert_eq!(Currency::free_balance(share_token, &user_2), 299_999_990_000);
 
 		assert_ok!(XYK::remove_liquidity(Origin::signed(user_2), asset_b, asset_a, 10_000));
@@ -488,7 +488,7 @@ fn work_flow_happy_path_should_work() {
 		let user_2_remove_2_balance_2 = Currency::free_balance(asset_b, &user_2);
 
 		assert_eq!(user_2_remove_2_balance_1, 999_483_333_368_888);
-		assert_eq!(user_2_remove_2_balance_2, 994_490_245_573_004);
+		assert_eq!(user_2_remove_2_balance_2, 994_487_000_450_586);
 		assert_eq!(Currency::free_balance(share_token, &user_2), 299_999_980_000);
 
 		// The two removes should be equal (this could slip by 1 because of rounding error)
@@ -517,20 +517,20 @@ fn work_flow_happy_path_should_work() {
 				user_2,
 				asset_a,
 				asset_b,
-				216_233_333_333,
-				6_490_245_122_554,
-				asset_a,
-				433_333_333,
+				216_666_666_666,
+				6_486_999_999_986,
+				asset_b,
+				12_999_999_999,
 			)
 			.into(),
 			Event::SellExecuted(
 				ALICE,
 				asset_a,
 				asset_b,
-				288_311_111_111,
-				4_870_118_901_375,
-				asset_a,
-				577_777_777,
+				288_888_888_888,
+				4_868_493_499_997,
+				asset_b,
+				9_756_499_999,
 			)
 			.into(),
 			Event::LiquidityRemoved(user_2, asset_a, asset_b, 10_000).into(),
@@ -598,13 +598,13 @@ fn sell_with_correct_fees_should_work() {
 		));
 
 		assert_eq!(Currency::free_balance(asset_a, &pair_account), 10100000);
-		assert_eq!(Currency::free_balance(asset_b, &pair_account), 1980237232,);
+		assert_eq!(Currency::free_balance(asset_b, &pair_account), 1980237622,);
 
 		assert_eq!(Currency::free_balance(asset_a, &user_1), 999999989900000);
-		assert_eq!(Currency::free_balance(asset_b, &user_1), 999998019762768,);
+		assert_eq!(Currency::free_balance(asset_b, &user_1), 999998019762378,);
 		expect_events(vec![
 			Event::PoolCreated(user_1, asset_a, asset_b, 2000000000).into(),
-			Event::SellExecuted(user_1, asset_a, asset_b, 99_800, 19_762_768, asset_a, 200).into(),
+			Event::SellExecuted(user_1, asset_a, asset_b, 100_000, 19_762_378, asset_b, 39_603).into(),
 		]);
 	});
 }
@@ -662,19 +662,19 @@ fn discount_sell_fees_should_work() {
 		assert_ok!(XYK::sell(Origin::signed(user_1), asset_a, asset_b, 10_000, 1_500, true,));
 
 		assert_eq!(Currency::free_balance(asset_a, &pair_account), 40_000);
-		assert_eq!(Currency::free_balance(asset_b, &pair_account), 45_007);
+		assert_eq!(Currency::free_balance(asset_b, &pair_account), 45_009);
 		assert_eq!(Currency::free_balance(asset_a, &native_pair_account), 5_000);
 		assert_eq!(Currency::free_balance(HDX, &native_pair_account), 10_000);
 
 		assert_eq!(Currency::free_balance(asset_a, &user_1), 955_000);
-		assert_eq!(Currency::free_balance(asset_b, &user_1), 954_993);
-		assert_eq!(Currency::free_balance(HDX, &user_1), 989_986);
+		assert_eq!(Currency::free_balance(asset_b, &user_1), 954_991);
+		assert_eq!(Currency::free_balance(HDX, &user_1), 989_980);
 
 		expect_events(vec![
 			Event::PoolCreated(user_1, asset_a, HDX, 10_000).into(),
 			frame_system::Event::NewAccount(pair_account).into(),
 			Event::PoolCreated(user_1, asset_a, asset_b, 60_000).into(),
-			Event::SellExecuted(user_1, asset_a, asset_b, 9_993, 14_993, asset_a, 7).into(),
+			Event::SellExecuted(user_1, asset_a, asset_b, 10_000, 14_991, asset_b, 10).into(),
 		]);
 	});
 }

--- a/pallets/xyk/src/tests.rs
+++ b/pallets/xyk/src/tests.rs
@@ -345,7 +345,7 @@ fn sell_test() {
 
 		expect_events(vec![
 			Event::PoolCreated(ALICE, asset_a, asset_b, 600000000000000).into(),
-			Event::SellExecuted(ALICE, asset_a, asset_b, 456444678, 1363489802256).into(),
+			Event::SellExecuted(ALICE, asset_a, asset_b, 455531789, 1363489802256, asset_a, 912889).into(),
 		]);
 	});
 }
@@ -513,8 +513,26 @@ fn work_flow_happy_path_should_work() {
 		expect_events(vec![
 			Event::PoolCreated(user_1, asset_a, asset_b, 350_000_000_000).into(),
 			Event::LiquidityAdded(user_2, asset_a, asset_b, 300_000_000_000, 12_000_000_000_000).into(),
-			Event::SellExecuted(user_2, asset_a, asset_b, 216_666_666_666, 6_490_245_122_554).into(),
-			Event::SellExecuted(ALICE, asset_a, asset_b, 288_888_888_888, 4_870_118_901_375).into(),
+			Event::SellExecuted(
+				user_2,
+				asset_a,
+				asset_b,
+				216_233_333_333,
+				6_490_245_122_554,
+				asset_a,
+				433_333_333,
+			)
+			.into(),
+			Event::SellExecuted(
+				ALICE,
+				asset_a,
+				asset_b,
+				288_311_111_111,
+				4_870_118_901_375,
+				asset_a,
+				577_777_777,
+			)
+			.into(),
 			Event::LiquidityRemoved(user_2, asset_a, asset_b, 10_000).into(),
 			Event::LiquidityRemoved(user_2, asset_b, asset_a, 10_000).into(),
 			Event::LiquidityRemoved(user_2, asset_a, asset_b, 18_000).into(),
@@ -586,7 +604,7 @@ fn sell_with_correct_fees_should_work() {
 		assert_eq!(Currency::free_balance(asset_b, &user_1), 999998019762768,);
 		expect_events(vec![
 			Event::PoolCreated(user_1, asset_a, asset_b, 2000000000).into(),
-			Event::SellExecuted(user_1, asset_a, asset_b, 100000, 19762768).into(),
+			Event::SellExecuted(user_1, asset_a, asset_b, 99_800, 19_762_768, asset_a, 200).into(),
 		]);
 	});
 }
@@ -656,7 +674,7 @@ fn discount_sell_fees_should_work() {
 			Event::PoolCreated(user_1, asset_a, HDX, 10_000).into(),
 			frame_system::Event::NewAccount(pair_account).into(),
 			Event::PoolCreated(user_1, asset_a, asset_b, 60_000).into(),
-			Event::SellExecuted(user_1, asset_a, asset_b, 10_000, 14_993).into(),
+			Event::SellExecuted(user_1, asset_a, asset_b, 9_993, 14_993, asset_a, 7).into(),
 		]);
 	});
 }
@@ -705,8 +723,17 @@ fn single_buy_should_work() {
 		assert_eq!(Currency::free_balance(asset_b, &pair_account), 960_639_995_191);
 
 		expect_events(vec![
-			Event::PoolCreated(user_1, asset_a, asset_b, 640000000000).into(),
-			Event::BuyExecuted(user_1, asset_a, asset_b, 66666666, 320639995191).into(),
+			Event::PoolCreated(user_1, asset_a, asset_b, 640_000_000_000).into(),
+			Event::BuyExecuted(
+				user_1,
+				asset_a,
+				asset_b,
+				66_666_666,
+				319_999_995_201,
+				asset_b,
+				639_999_990,
+			)
+			.into(),
 		]);
 	});
 }
@@ -777,7 +804,16 @@ fn single_buy_with_discount_should_work() {
 			Event::PoolCreated(user_1, asset_a, asset_b, 640_000_000_000).into(),
 			frame_system::Event::NewAccount(native_pair_account).into(),
 			Event::PoolCreated(user_1, asset_a, HDX, 100_000_000_000).into(),
-			Event::BuyExecuted(user_1, asset_a, asset_b, 66_666_666, 320_223_995_197).into(),
+			Event::BuyExecuted(
+				user_1,
+				asset_a,
+				asset_b,
+				66_666_666,
+				319_999_995_201,
+				asset_b,
+				223_999_996,
+			)
+			.into(),
 		]);
 	});
 }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ['GalacticCouncil']
 edition = '2018'
 name = 'primitives'
-version = '4.0.0'
+version = '4.1.0'
 
 [build-dependencies]
 substrate-wasm-builder = {package = 'substrate-wasm-builder', version = '3.0.0'}

--- a/primitives/src/traits.rs
+++ b/primitives/src/traits.rs
@@ -23,13 +23,14 @@ use sp_std::vec::Vec;
 
 /// Hold information to perform amm transfer
 /// Contains also exact amount which will be sold/bought
-pub struct AMMTransfer<AccountId, AssetPair, Balance> {
+pub struct AMMTransfer<AccountId, AssetId, AssetPair, Balance> {
 	pub origin: AccountId,
 	pub assets: AssetPair,
 	pub amount: Balance,
 	pub amount_out: Balance,
 	pub discount: bool,
 	pub discount_amount: Balance,
+	pub fee: (AssetId, Balance),
 }
 
 /// Traits for handling AMM Pool trades.
@@ -54,10 +55,10 @@ pub trait AMM<AccountId, AssetId, AssetPair, Amount> {
 		amount: Amount,
 		min_bought: Amount,
 		discount: bool,
-	) -> Result<AMMTransfer<AccountId, AssetPair, Amount>, frame_support::sp_runtime::DispatchError>;
+	) -> Result<AMMTransfer<AccountId, AssetId, AssetPair, Amount>, frame_support::sp_runtime::DispatchError>;
 
 	/// Execute buy for given validated transfer.
-	fn execute_sell(transfer: &AMMTransfer<AccountId, AssetPair, Amount>) -> dispatch::DispatchResult;
+	fn execute_sell(transfer: &AMMTransfer<AccountId, AssetId, AssetPair, Amount>) -> dispatch::DispatchResult;
 
 	/// Perform asset swap.
 	/// Call execute following the validation.
@@ -80,10 +81,10 @@ pub trait AMM<AccountId, AssetId, AssetPair, Amount> {
 		amount: Amount,
 		max_limit: Amount,
 		discount: bool,
-	) -> Result<AMMTransfer<AccountId, AssetPair, Amount>, frame_support::sp_runtime::DispatchError>;
+	) -> Result<AMMTransfer<AccountId, AssetId, AssetPair, Amount>, frame_support::sp_runtime::DispatchError>;
 
 	/// Execute buy for given validated transfer.
-	fn execute_buy(transfer: &AMMTransfer<AccountId, AssetPair, Amount>) -> dispatch::DispatchResult;
+	fn execute_buy(transfer: &AMMTransfer<AccountId, AssetId, AssetPair, Amount>) -> dispatch::DispatchResult;
 
 	/// Perform asset swap.
 	fn buy(

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -5,7 +5,7 @@ homepage = 'https://github.com/galacticcouncil/hydradx-node'
 license = 'Apache 2.0'
 name = 'hydra-dx-runtime'
 repository = 'https://github.com/galacticcouncil/hydradx-node'
-version = '15.0.1'
+version = '15.1.0'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -149,7 +149,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("hydra-dx"),
 	authoring_version: 1,
 	spec_version: 15,
-	impl_version: 1,
+	impl_version: 2,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 };


### PR DESCRIPTION
The AMMTransfer struct is extended to contain two new fields: fee_assetID and fee_amount.

## Description
The fee amount is subtracted from the amount_in variable in the AMMTransfer struct.

## Motivation and Context
This change is required in LBP pallet because we need a way to access the fee in `execute_buy/sell(transfer: AMMTransfer)` functions and send it to corresponding fee_receiver account.

