### PR TITLE
ci: fix incorrect output from version check

### DIFF
--- a/scripts/list_crate_updates.sh
+++ b/scripts/list_crate_updates.sh
@@ -181,7 +181,7 @@ if [ ${#RUNTIME_VERSION_DIFFS[@]} -ne 0 ]; then
 fi
 
 RUNTIME_CARGO_VERSIONS=( $(printf '%s\n' "${RUNTIME_CARGO_VERSIONS[@]}" | sort -u) )
-if [ ${#RUNTIME_CARGO_VERSIONS} -gt 1 ]; then
+if [ ${#RUNTIME_CARGO_VERSIONS[@]} -gt 1 ]; then
   echo "Runtime versions don't match."
   echo
 fi


### PR DESCRIPTION
Fix: version check always reports that runtime versions don't match.