### PR TITLE
feat: added vesting account and lowered minimal vested transfer

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -250,7 +250,7 @@ parameter_types! {
 
 // pallet vesting
 parameter_types! {
-	pub MinVestedTransfer: Balance = 1_000;
+	pub MinVestedTransfer: Balance = 100;
 	pub const MaxVestingSchedules: u32 = 100;
 	pub const VestingPalletId: PalletId = PalletId(*b"py/vstng");
 }

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -252,6 +252,7 @@ parameter_types! {
 parameter_types! {
 	pub MinVestedTransfer: Balance = NativeExistentialDeposit::get();
 	pub const MaxVestingSchedules: u32 = 100;
+	pub const VestingPalletId: PalletId = PalletId(*b"py/vstng");
 }
 
 // pallet proxy

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -250,7 +250,7 @@ parameter_types! {
 
 // pallet vesting
 parameter_types! {
-	pub MinVestedTransfer: Balance = NativeExistentialDeposit::get();
+	pub MinVestedTransfer: Balance = 1_000;
 	pub const MaxVestingSchedules: u32 = 100;
 	pub const VestingPalletId: PalletId = PalletId(*b"py/vstng");
 }

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -24,8 +24,8 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use codec::{Decode, Encode};
-use scale_info::TypeInfo;
 use frame_system::{EnsureRoot, RawOrigin};
+use scale_info::TypeInfo;
 use sp_api::impl_runtime_apis;
 use sp_core::{
 	u32_trait::{_1, _2, _3},
@@ -47,24 +47,27 @@ use sp_version::RuntimeVersion;
 // A few exports that help ease life for downstream crates.
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{Currency as PalletCurrency, EnsureOrigin, EnsureOneOf, Everything, Get, Imbalance, InstanceFilter, OnUnbalanced, PrivilegeCmp, U128CurrencyToVote},
+	traits::{
+		Currency as PalletCurrency, EnsureOneOf, EnsureOrigin, Everything, Get, Imbalance, InstanceFilter,
+		OnUnbalanced, PrivilegeCmp, U128CurrencyToVote,
+	},
 	weights::{
 		constants::{BlockExecutionWeight, RocksDbWeight},
 		DispatchClass, Weight, WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
 	},
 };
-use primitives::Price;
 use hydradx_traits::pools::SpotPriceProvider;
 use pallet_transaction_payment::{CurrencyAdapter, TargetedFeeAdjustment};
+use primitives::Price;
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_runtime::traits::BlockNumberProvider;
 
+pub use common_runtime::*;
 use orml_currencies::BasicCurrencyAdapter;
 use orml_traits::parameter_type_with_key;
-pub use common_runtime::*;
 
-mod xcm;
 mod benchmarking;
+mod xcm;
 
 /// Import HydraDX pallets
 pub use pallet_claims;
@@ -586,14 +589,16 @@ impl orml_currencies::Config for Runtime {
 	type WeightInfo = ();
 }
 
-pub struct GalacticCouncilOrRoot;
-impl EnsureOrigin<Origin> for GalacticCouncilOrRoot {
+pub struct GalacticCouncilOrVestingOrRoot;
+impl EnsureOrigin<Origin> for GalacticCouncilOrVestingOrRoot {
 	type Success = AccountId;
 
 	fn try_origin(o: Origin) -> Result<Self::Success, Origin> {
 		Into::<Result<RawOrigin<AccountId>, Origin>>::into(o).and_then(|o| match o {
 			RawOrigin::Signed(caller) => {
-				if caller == primitives::constants::chain::GALACTIC_COUNCIL_ACCOUNT.into() {
+				if caller == primitives::constants::chain::GALACTIC_COUNCIL_ACCOUNT.into()
+					|| caller == VestingPalletId::get().into_account()
+				{
 					Ok(caller)
 				} else {
 					Err(Origin::from(Some(caller)))
@@ -614,7 +619,7 @@ impl orml_vesting::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
 	type MinVestedTransfer = MinVestedTransfer;
-	type VestedTransferOrigin = GalacticCouncilOrRoot;
+	type VestedTransferOrigin = GalacticCouncilOrVestingOrRoot;
 	type WeightInfo = ();
 	type MaxVestingSchedules = MaxVestingSchedules;
 	type BlockNumberProvider = RelayChainBlockNumberProvider<Runtime>;

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -33,7 +33,7 @@ use sp_core::{
 };
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
-	traits::{BlakeTwo256, Block as BlockT, IdentityLookup, Zero},
+	traits::{AccountIdConversion, BlakeTwo256, Block as BlockT, IdentityLookup, Zero},
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, Perbill,
 };

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -69,6 +69,11 @@ use orml_traits::parameter_type_with_key;
 mod benchmarking;
 mod xcm;
 
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
 /// Import HydraDX pallets
 pub use pallet_claims;
 pub use pallet_genesis_history;

--- a/runtime/hydradx/src/mock.rs
+++ b/runtime/hydradx/src/mock.rs
@@ -1,0 +1,122 @@
+use frame_support::{parameter_types, traits::Everything, PalletId};
+use frame_system as system;
+use primitives::constants::chain::GALACTIC_COUNCIL_ACCOUNT;
+use sp_core::{crypto::AccountId32, H256};
+use sp_runtime::{
+	testing::Header,
+	traits::{AccountIdConversion, BlakeTwo256, IdentityLookup},
+};
+
+pub type AccountId = AccountId32;
+pub type Balance = u128;
+type ReserveIdentifier = [u8; 8];
+
+pub const HDX: Balance = 100_000_000_000;
+
+pub const ALICE: AccountId = AccountId::new([1u8; 32]);
+pub const BOB: AccountId = AccountId::new([2u8; 32]);
+pub const CHARLIE: AccountId = AccountId::new([3u8; 32]);
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+	}
+);
+
+parameter_types! {
+	pub const ExistentialDeposit: u128 = 500;
+	pub const MaxReserves: u32 = 50;
+}
+
+impl pallet_balances::Config for Test {
+	type Balance = Balance;
+	type Event = Event;
+	type DustRemoval = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = frame_system::Pallet<Test>;
+	type MaxLocks = ();
+	type WeightInfo = ();
+	type MaxReserves = MaxReserves;
+	type ReserveIdentifier = ReserveIdentifier;
+}
+
+parameter_types! {
+  pub const BlockHashCount: u64 = 250;
+	pub const SS58Prefix: u8 = 42;
+}
+
+impl system::Config for Test {
+	type BaseCallFilter = Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type Origin = Origin;
+	type Call = Call;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = SS58Prefix;
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+parameter_types! {
+  pub const VestingPalletId: PalletId = PalletId(*b"py/vstng");
+}
+
+pub fn vesting_account() -> AccountId {
+	VestingPalletId::get().into_account()
+}
+
+pub struct ExtBuilder;
+impl Default for ExtBuilder {
+	fn default() -> Self {
+		ExtBuilder
+	}
+}
+
+impl ExtBuilder {
+	pub fn build(self) -> sp_io::TestExternalities {
+		let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+
+		pallet_balances::GenesisConfig::<Test> {
+			balances: vec![
+				(ALICE, 40_000 * HDX),
+				(BOB, 2_000 * HDX),
+				(CHARLIE, 4_000 * HDX),
+				(vesting_account(), 50_000 * HDX),
+				(GALACTIC_COUNCIL_ACCOUNT.into(), 50_000 * HDX),
+			],
+		}
+		.assimilate_storage(&mut t)
+		.unwrap();
+
+		let mut ext = sp_io::TestExternalities::new(t);
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
+}
+
+pub fn set_block_number<T: frame_system::Config<BlockNumber = u64>>(n: u64) {
+	frame_system::Pallet::<T>::set_block_number(n);
+}

--- a/runtime/hydradx/src/tests/mod.rs
+++ b/runtime/hydradx/src/tests/mod.rs
@@ -1,0 +1,11 @@
+use super::*;
+use crate::mock::*;
+
+#[cfg(test)]
+mod vested_transfer;
+
+fn new_test_ext() -> sp_io::TestExternalities {
+	let mut ext = ExtBuilder::default().build();
+	ext.execute_with(|| set_block_number::<Test>(1));
+	ext
+}

--- a/runtime/hydradx/src/tests/vested_transfer.rs
+++ b/runtime/hydradx/src/tests/vested_transfer.rs
@@ -1,0 +1,65 @@
+use super::*;
+use frame_support::{assert_noop, assert_ok};
+use orml_vesting::VestingSchedule;
+use sp_core::crypto::AccountId32;
+use sp_runtime::traits::BadOrigin;
+
+type AccountId = AccountId32;
+type Balance = u128;
+type Schedule = VestingSchedule<BlockNumber, Balance>;
+
+fn schedule_object() -> Schedule {
+	Schedule {
+		start: 0,
+		period: 1,
+		period_count: 3,
+		per_period: 1_100,
+	}
+}
+
+#[test]
+fn vested_transfer_from_vesting_account_should_work() {
+	new_test_ext().execute_with(|| {
+		let from: AccountId = vesting_account();
+		let to: AccountId = BOB;
+
+		let vesting_schedule = schedule_object();
+
+		assert_ok!(Vesting::vested_transfer(
+			RawOrigin::Signed(from).into(),
+			to,
+			vesting_schedule
+		));
+	});
+}
+
+#[test]
+fn vested_transfer_from_gc_account_should_work() {
+	new_test_ext().execute_with(|| {
+		let from: AccountId = GALACTIC_COUNCIL_ACCOUNT.into();
+		let to: AccountId = BOB;
+
+		let vesting_schedule = schedule_object();
+
+		assert_ok!(Vesting::vested_transfer(
+			RawOrigin::Signed(from).into(),
+			to,
+			vesting_schedule
+		));
+	});
+}
+
+#[test]
+fn vested_transfer_from_other_account_than_gc_and_vesting_should_not_work() {
+	new_test_ext().execute_with(|| {
+		let from: AccountId = ALICE;
+		let to: AccountId = BOB;
+
+		let vesting_schedule = schedule_object();
+
+		assert_noop!(
+			Vesting::vested_transfer(RawOrigin::Signed(from).into(), to, vesting_schedule),
+			BadOrigin
+		);
+	});
+}

--- a/runtime/testing-hydradx/src/lib.rs
+++ b/runtime/testing-hydradx/src/lib.rs
@@ -33,7 +33,7 @@ use sp_core::{
 };
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
-	traits::{BlakeTwo256, Block as BlockT, IdentityLookup, Zero},
+	traits::{AccountIdConversion, BlakeTwo256, Block as BlockT, IdentityLookup, Zero},
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, Perbill,
 };
@@ -629,7 +629,7 @@ impl orml_vesting::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
 	type MinVestedTransfer = MinVestedTransfer;
-	type VestedTransferOrigin = GalacticCouncilOrRoot;
+	type VestedTransferOrigin = GalacticCouncilOrVestingOrRoot;
 	type WeightInfo = ();
 	type MaxVestingSchedules = MaxVestingSchedules;
 	type BlockNumberProvider = RelayChainBlockNumberProvider<Runtime>;

--- a/runtime/testing-hydradx/src/lib.rs
+++ b/runtime/testing-hydradx/src/lib.rs
@@ -24,8 +24,8 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use codec::{Decode, Encode};
-use scale_info::TypeInfo;
 use frame_system::{EnsureRoot, RawOrigin};
+use scale_info::TypeInfo;
 use sp_api::impl_runtime_apis;
 use sp_core::{
 	u32_trait::{_1, _2, _3},
@@ -47,21 +47,24 @@ use sp_version::RuntimeVersion;
 // A few exports that help ease life for downstream crates.
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{Currency as PalletCurrency, EnsureOrigin, EnsureOneOf, Get, Imbalance, InstanceFilter, OnUnbalanced, PrivilegeCmp, EqualPrivilegeOnly, Everything, U128CurrencyToVote},
+	traits::{
+		Currency as PalletCurrency, EnsureOneOf, EnsureOrigin, EqualPrivilegeOnly, Everything, Get, Imbalance,
+		InstanceFilter, OnUnbalanced, PrivilegeCmp, U128CurrencyToVote,
+	},
 	weights::{
 		constants::{BlockExecutionWeight, RocksDbWeight},
 		DispatchClass, Weight, WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
 	},
 };
-use primitives::Price;
 use hydradx_traits::pools::SpotPriceProvider;
 use pallet_transaction_payment::{CurrencyAdapter, TargetedFeeAdjustment};
+use primitives::Price;
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_runtime::traits::BlockNumberProvider;
 
+pub use common_runtime::*;
 use orml_currencies::BasicCurrencyAdapter;
 use orml_traits::parameter_type_with_key;
-pub use common_runtime::*;
 
 mod xcm;
 
@@ -596,14 +599,16 @@ impl orml_currencies::Config for Runtime {
 	type WeightInfo = ();
 }
 
-pub struct GalacticCouncilOrRoot;
-impl EnsureOrigin<Origin> for GalacticCouncilOrRoot {
+pub struct GalacticCouncilOrVestingOrRoot;
+impl EnsureOrigin<Origin> for GalacticCouncilOrVestingOrRoot {
 	type Success = AccountId;
 
 	fn try_origin(o: Origin) -> Result<Self::Success, Origin> {
 		Into::<Result<RawOrigin<AccountId>, Origin>>::into(o).and_then(|o| match o {
 			RawOrigin::Signed(caller) => {
-				if caller == primitives::constants::chain::GALACTIC_COUNCIL_ACCOUNT.into() {
+				if caller == primitives::constants::chain::GALACTIC_COUNCIL_ACCOUNT.into()
+					|| caller == VestingPalletId::get().into_account()
+				{
 					Ok(caller)
 				} else {
 					Err(Origin::from(Some(caller)))

--- a/scripts/upgrade-runtime/index.js
+++ b/scripts/upgrade-runtime/index.js
@@ -64,7 +64,7 @@ async function main() {
   console.log(`connected to ${chain} ${nodeVersion}`);
   console.log(`current runtime version ${specVersion}`);
 
-  assert.equal(hdxAddress(sudoKey), hdxAddress(from.addressRaw), `imported account doesn't match sudo key`);
+  assert.equal(hdxAddress(sudoKey.unwrap()), hdxAddress(from.addressRaw), `imported account doesn't match sudo key`);
   const setCode = api.tx.system.setCode(code);
   const sudo = api.tx.sudo.sudoUncheckedWeight(setCode, 100);
 

--- a/scripts/upgrade-runtime/package-lock.json
+++ b/scripts/upgrade-runtime/package-lock.json
@@ -5,8 +5,9 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "upgrade-runtime",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^6.11.1",
         "@polkadot/util-crypto": "^8.1.2",


### PR DESCRIPTION
Related to https://github.com/galacticcouncil/HydraDX-node/issues/373 and https://github.com/galacticcouncil/Basilisk-crowdloan-ui/issues/30

* adds vesting account to whitelist for vested_transfer
* lowers MinVestedTransfer to allow for vestings under existential deposit