### PR TITLE
fix: migration - use weight split

### DIFF
--- a/scripts/snakenet-migration/index.js
+++ b/scripts/snakenet-migration/index.js
@@ -701,10 +701,15 @@ async function main() {
         log(`Weight limit: ${weightLimit.toHuman()}`);
         weightLimit = new BN(weightLimit.toString());
 
-        // utility batch can have only so many calls, so let's divide by that and then check the weight of each batch
-        //const blocks = weight.div(weightLimit).toNumber() + 1;
-        const blocks = new BN(storageUpdates.length).div(batch_calls).toNumber() + 1;
+        const blocks = weight.div(weightLimit).toNumber() + 1;
         log(`Batch have to be split into ${blocks} blocks`);
+
+         //utility batch can have only so many calls, so let's check if the split contains > max limit
+	const per_batch = storage.length / blocks;
+	if (per_batch > batch_calls){
+	    log(chalk.red(`Max calls in batch exceeded`));
+	    process.exit(1);
+	}
 
         const updatesPerBlock = Math.ceil(storageUpdates.length / blocks);
         const chunks = chunkify(storageUpdates, updatesPerBlock)

--- a/scripts/snakenet-migration/index.js
+++ b/scripts/snakenet-migration/index.js
@@ -705,13 +705,12 @@ async function main() {
         log(`Batch have to be split into ${blocks} blocks`);
 
          //utility batch can have only so many calls, so let's check if the split contains > max limit
-	const per_batch = storage.length / blocks;
-	if (per_batch > batch_calls){
-	    log(chalk.red(`Max calls in batch exceeded`));
-	    process.exit(1);
-	}
-
         const updatesPerBlock = Math.ceil(storageUpdates.length / blocks);
+        if (updatesPerBlock > batch_calls){
+            log(chalk.red(`Max calls in batch exceeded`));
+            process.exit(1);
+        }
+
         const chunks = chunkify(storageUpdates, updatesPerBlock)
             .map(updates => api.tx.utility.batch(updates));
 


### PR DESCRIPTION
Use weight split instead of call split because weight limits are different in parachain setup. 

Added check of max calls per batch too to not exceed max call per batch.