### PR TITLE
Fix: update README about spinning up node with local testnet 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,34 +37,40 @@ cargo build --release
 
 ## Run
 
-### Single Node Development Chain
+### Local Testnet
 
-Purge any existing dev chain state:
+Relay chain repository (polkadot) has to be built in `../polkadot`
+Install `polkadot-launch` utility used to start network.
 
-```bash
-./target/release/hydra-dx purge-chain --dev
+```
+npm install -g polkadot-launch
 ```
 
-Start a dev chain:
+Start local testnet with 4 relay chain validators and HydraDX as a parachain with 2 collators.
 
-```bash
-./target/release/hydra-dx --dev
+```
+cd ./rococo-local
+polkadot-launch config.json
 ```
 
-Or, start a dev chain with detailed logging:
+Observe HydraDX logs
 
-```bash
-RUST_LOG=debug RUST_BACKTRACE=1 ./target/release/hydra-dx -lruntime=debug --dev
+```
+multitail 99*.log
 ```
 
-There is also an option to run the testing runtime with less restrictive settings to facilitate testing of new features.
-The following command starts a dev chain, and the testing runtime is used as a runtime for our node.
-```bash
-./target/release/hydra-dx --dev --runtime=testing
+### Use testing runtime
+
+In the case of starting a testnet using the `polkadot-launch` tool, 
+we don't have an option to communicate to its internal commands that we would like to use the testing runtime.
+To overcome this limitation, rename the binary so it starts with the `testing` prefix, e.g. `testing-hydradx`.
+Such a binary always uses the testing runtime, even if the `--runtime testing` option is not specified.
+
+Start local testnet with testing runtime
 ```
-The testing runtime currently supports only two chain specifications: _dev_ and _local_ testnet.
-Both runtimes store blockchain data in the same directories( e.g. the _dev_ directory is shared for both runtimes 
-started with the `--dev` parameter. That's why it is important to purge chain data when switching to different runtime( note: `--runtime` parameter can't be used when purging chain data)
+cd ./rococo-local
+polkadot-launch testing-config.json
+```
 
 ### Interaction with the node
 

--- a/rococo-local/testing-config.json
+++ b/rococo-local/testing-config.json
@@ -1,0 +1,62 @@
+{
+    "relaychain": {
+      "bin": "../../polkadot/target/release/polkadot",
+      "chain": "rococo-local",
+      "nodes": [
+        {
+          "name": "alice",
+          "wsPort": 9944,
+          "port": 30444
+        },
+        {
+          "name": "bob",
+          "wsPort": 9955,
+          "port": 30555
+        },
+        {
+          "name": "charlie",
+          "wsPort": 9966,
+          "port": 30666
+        },
+        {
+          "name": "dave",
+          "wsPort": 9977,
+          "port": 30777
+        }
+      ],
+      "genesis": {
+        "runtime": {
+          "runtime_genesis_config": {
+            "configuration": {
+              "config": {
+                "validation_upgrade_frequency": 1,
+                "validation_upgrade_delay": 10
+              }
+            }
+          }
+        }
+      }
+    },
+    "simpleParachains": [],
+    "parachains": [
+      {
+        "bin": "../target/release/testing-hydradx",
+        "chain":"local",
+        "balance": "1000000000000000000000",
+        "nodes": [
+          {
+            "wsPort": 9988,
+            "port": 31200,
+            "flags": ["--alice", "--rpc-cors=all", "--", "--execution=wasm"]
+          },
+          {
+            "wsPort": 9989,
+            "port": 31201,
+            "flags": ["--bob", "--rpc-cors=all", "--", "--execution=wasm"]
+          }
+        ]
+      }
+    ],
+    "hrmpChannels": [],
+    "types": {}
+  }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- We are using semantinc pull request to make our lives easier -->
<!--- Please use prefixes for the title and use ! before : if breaking like below -->
<!--- build: ci: docs: feat: perf: refactor: fix: style: test: refactor!: -->

## Description
We realized that the README about running the node with local testnet is outdated on our parachain branch. So I used the same setup as in Basilisk-node (master). Next to that, I also added a testing-config.json (to use testing runtime) as Lumir noted that that was also missing.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue below using keyword like: Fixes: #0 -->

## Motivation and Context
See description

## How Has This Been Tested?
I executed the commands described in the updated README to see if the node can be launched.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation if necessary.
- [ ] I have added tests to cover my changes, regression test if fixing an issue.
- [ ] This is a breaking change.
