### PR TITLE
fix: omnipool imbalance subtraction 

### DIFF
--- a/pallets/omnipool/src/tests/types.rs
+++ b/pallets/omnipool/src/tests/types.rs
@@ -130,7 +130,7 @@ fn simple_imbalance_subtraction_works() {
 		} - 300,
 		Some(SimpleImbalance {
 			value: 0,
-			negative: false
+			negative: true,
 		})
 	);
 	assert_eq!(

--- a/pallets/omnipool/src/types.rs
+++ b/pallets/omnipool/src/types.rs
@@ -202,6 +202,8 @@ impl<Balance: CheckedAdd + CheckedSub + PartialOrd + Copy> Sub<Balance> for Simp
 			(self.value.checked_add(&amount)?, self.negative)
 		} else if self.value < amount {
 			(amount.checked_sub(&self.value)?, true)
+		} else if self.value == amount {
+			(self.value.checked_sub(&amount)?, true)
 		} else {
 			(self.value.checked_sub(&amount)?, self.negative)
 		};


### PR DESCRIPTION
Fixed #432 

Sign should be consistent for 0 value. In case of sub - it could result in positive.

