### PR TITLE
fix: correctly update hdx subpool hub reserve

### DIFF
--- a/pallets/omnipool/src/lib.rs
+++ b/pallets/omnipool/src/lib.rs
@@ -990,6 +990,9 @@ pub mod pallet {
 				.ok_or(ArithmeticError::Overflow)?;
 
 			match delta_hub_asset {
+				BalanceUpdate::Increase(val) if val == Balance::zero() => {
+					// nothing to do if zero.
+				}
 				BalanceUpdate::Increase(_) => {
 					// trade can only burn some.
 					return Err(Error::<T>::HubAssetUpdateError.into());
@@ -1126,6 +1129,9 @@ pub mod pallet {
 				.ok_or(ArithmeticError::Overflow)?;
 
 			match delta_hub_asset {
+				BalanceUpdate::Increase(val) if val == Balance::zero() => {
+					// nothing to do if zero.
+				}
 				BalanceUpdate::Increase(_) => {
 					// trade can only burn some.
 					return Err(Error::<T>::HubAssetUpdateError.into());

--- a/pallets/omnipool/src/lib.rs
+++ b/pallets/omnipool/src/lib.rs
@@ -329,7 +329,7 @@ pub mod pallet {
 		InsufficientTradingAmount,
 		/// Sell or buy with same asset ids is not allowed.
 		SameAssetTradeNotAllowed,
-		/// LRNA update after trade results in non-zero value.
+		/// LRNA update after trade results in positive value.
 		HubAssetUpdateError,
 	}
 

--- a/pallets/omnipool/src/lib.rs
+++ b/pallets/omnipool/src/lib.rs
@@ -329,6 +329,8 @@ pub mod pallet {
 		InsufficientTradingAmount,
 		/// Sell or buy with same asset ids is not allowed.
 		SameAssetTradeNotAllowed,
+		/// LRNA update after trade results in non-zero value.
+		HubAssetUpdateError,
 	}
 
 	#[pallet::call]
@@ -980,14 +982,14 @@ pub mod pallet {
 				)
 				.ok_or(ArithmeticError::Overflow)?;
 
-			Self::update_hub_asset_liquidity(&delta_hub_asset)?;
+			ensure!(*delta_hub_asset == Balance::zero(), Error::<T>::HubAssetUpdateError);
 
 			Self::update_imbalance(current_imbalance, state_changes.delta_imbalance)?;
 
-			Self::update_hdx_subpool_hub_asset(state_changes.hdx_hub_amount)?;
-
 			Self::set_asset_state(asset_in, new_asset_in_state);
 			Self::set_asset_state(asset_out, new_asset_out_state);
+
+			Self::update_hdx_subpool_hub_asset(state_changes.hdx_hub_amount)?;
 
 			Self::deposit_event(Event::SellExecuted {
 				who,
@@ -1107,14 +1109,15 @@ pub mod pallet {
 						.ok_or(ArithmeticError::Overflow)?,
 				)
 				.ok_or(ArithmeticError::Overflow)?;
-			Self::update_hub_asset_liquidity(&delta_hub_asset)?;
 
-			Self::update_hdx_subpool_hub_asset(state_changes.hdx_hub_amount)?;
+			ensure!(*delta_hub_asset == Balance::zero(), Error::<T>::HubAssetUpdateError);
 
 			Self::update_imbalance(current_imbalance, state_changes.delta_imbalance)?;
 
 			Self::set_asset_state(asset_in, new_asset_in_state);
 			Self::set_asset_state(asset_out, new_asset_out_state);
+
+			Self::update_hdx_subpool_hub_asset(state_changes.hdx_hub_amount)?;
 
 			Self::deposit_event(Event::BuyExecuted {
 				who,

--- a/pallets/omnipool/src/tests/mod.rs
+++ b/pallets/omnipool/src/tests/mod.rs
@@ -51,6 +51,8 @@ macro_rules! assert_balance_approx {
 #[macro_export]
 macro_rules! assert_pool_state {
 	( $x:expr, $y:expr, $z:expr) => {{
+		//let hub_reserves: Vec<Balance> = Assets::<Test>::iter().map(|v| v.1.hub_reserve).collect();
+		//assert_eq!($x, hub_reserves.iter().sum::<Balance>());
 		assert_eq!(
 			Tokens::free_balance(LRNA, &Omnipool::protocol_account()),
 			$x,

--- a/pallets/omnipool/src/tests/mod.rs
+++ b/pallets/omnipool/src/tests/mod.rs
@@ -49,10 +49,22 @@ macro_rules! assert_balance_approx {
 }
 
 #[macro_export]
+macro_rules! assert_hub_asset {
+	( ) => {{
+		let hub_reserves: Vec<Balance> = Assets::<Test>::iter().map(|v| v.1.hub_reserve).collect();
+		assert_eq!(
+			Tokens::free_balance(LRNA, &Omnipool::protocol_account()),
+			hub_reserves.iter().sum::<Balance>(),
+			"Hub liquidity incorrect\n"
+		);
+	}};
+}
+
+#[macro_export]
 macro_rules! assert_pool_state {
 	( $x:expr, $y:expr, $z:expr) => {{
-		//let hub_reserves: Vec<Balance> = Assets::<Test>::iter().map(|v| v.1.hub_reserve).collect();
-		//assert_eq!($x, hub_reserves.iter().sum::<Balance>());
+		let hub_reserves: Vec<Balance> = Assets::<Test>::iter().map(|v| v.1.hub_reserve).collect();
+		assert_eq!($x, hub_reserves.iter().sum::<Balance>());
 		assert_eq!(
 			Tokens::free_balance(LRNA, &Omnipool::protocol_account()),
 			$x,

--- a/pallets/omnipool/src/tests/remove_liquidity.rs
+++ b/pallets/omnipool/src/tests/remove_liquidity.rs
@@ -241,7 +241,7 @@ fn lp_receives_lrna_when_price_is_higher() {
 			assert_balance!(LP1, 1000, 4_760_000_000_000_000);
 			assert_balance!(LP1, LRNA, 470_689_655_172_413);
 
-			assert_pool_state!(9704310344827587, 541000000000086413, SimpleImbalance::default());
+			assert_pool_state!(10175000000000000, 541000000000086413, SimpleImbalance::default());
 		});
 }
 

--- a/pallets/omnipool/src/tests/verification/scenario_08.rs
+++ b/pallets/omnipool/src/tests/verification/scenario_08.rs
@@ -22,7 +22,11 @@ fn complex_scenario_works() {
 		.with_token(200, FixedU128::from_float(1.1), LP1, 2000 * ONE)
 		.build()
 		.execute_with(|| {
+			assert_hub_asset!();
+
 			assert_ok!(Omnipool::add_liquidity(Origin::signed(LP2), 100, 400000000000000));
+
+			assert_hub_asset!();
 
 			assert_ok!(Omnipool::sell(
 				Origin::signed(LP3),
@@ -50,7 +54,11 @@ fn complex_scenario_works() {
 				100000000000000000
 			));
 
+			assert_hub_asset!();
+
 			assert_ok!(Omnipool::remove_liquidity(Origin::signed(LP3), 3, 200000000000000));
+
+			assert_hub_asset!();
 
 			assert_ok!(Omnipool::sell(
 				Origin::signed(LP3),
@@ -62,7 +70,7 @@ fn complex_scenario_works() {
 
 			assert_balance_approx!(Omnipool::protocol_account(), 0, NATIVE_AMOUNT, 10);
 			assert_balance_approx!(Omnipool::protocol_account(), 2, 1000000000000000u128, 10);
-			assert_balance_approx!(Omnipool::protocol_account(), 1, 14211575191619508u128, 10);
+			assert_balance_approx!(Omnipool::protocol_account(), 1, 14252209513698901u128, 10);
 			assert_balance_approx!(Omnipool::protocol_account(), 100, 3589236949625567u128, 10);
 			assert_balance_approx!(Omnipool::protocol_account(), 200, 1638588974363038u128, 10);
 			assert_balance_approx!(LP1, 100, 3000000000000000u128, 10);
@@ -126,12 +134,14 @@ fn complex_scenario_works() {
 			);
 
 			assert_pool_state!(
-				14211575191619509,
+				14252209513698901,
 				29498181728191026,
 				SimpleImbalance {
 					value: 39852348990836,
 					negative: true
 				}
 			);
+
+			assert_ok!(Omnipool::sell(Origin::signed(LP3), 100, 200, 20000000000000, 1,));
 		});
 }

--- a/pallets/omnipool/src/tests/verification/scenario_10.rs
+++ b/pallets/omnipool/src/tests/verification/scenario_10.rs
@@ -56,7 +56,7 @@ fn fee_test_buy_sell() {
 
 			assert_balance_approx!(Omnipool::protocol_account(), 0, NATIVE_AMOUNT, 10);
 			assert_balance_approx!(Omnipool::protocol_account(), 2, 1000000000000000u128, 10);
-			assert_balance_approx!(Omnipool::protocol_account(), 1, 14182282238540066u128, 10);
+			assert_balance_approx!(Omnipool::protocol_account(), 1, 14225180042050832u128, 10);
 			assert_balance_approx!(Omnipool::protocol_account(), 100, 4243052260380446u128, 10);
 			assert_balance_approx!(Omnipool::protocol_account(), 200, 1671684145777546u128, 10);
 			assert_balance_approx!(LP1, 100, 3000000000000000u128, 10);
@@ -120,7 +120,7 @@ fn fee_test_buy_sell() {
 			);
 
 			assert_pool_state!(
-				14182282238540070, // hub liquidity
+				14225180042050832,
 				29534546221723530,
 				SimpleImbalance {
 					value: 0,

--- a/pallets/omnipool/src/tests/verification/scenario_11.rs
+++ b/pallets/omnipool/src/tests/verification/scenario_11.rs
@@ -64,7 +64,7 @@ fn complex_scenario_works() {
 
 			assert_balance_approx!(Omnipool::protocol_account(), 0, NATIVE_AMOUNT, 10);
 			assert_balance_approx!(Omnipool::protocol_account(), 2, 1000000000000000u128, 10);
-			assert_balance_approx!(Omnipool::protocol_account(), 1, 14356887226495360u128, 10);
+			assert_balance_approx!(Omnipool::protocol_account(), 1, 14397521548574755u128, 10);
 			assert_balance_approx!(Omnipool::protocol_account(), 100, 4089236949625567u128, 10);
 			assert_balance_approx!(Omnipool::protocol_account(), 200, 1638588974363038u128, 10);
 			assert_balance_approx!(LP1, 100, 3000000000000000u128, 10);
@@ -128,10 +128,10 @@ fn complex_scenario_works() {
 			);
 
 			assert_pool_state!(
-				14356887226495363,
+				14397521548574755,
 				28755043097149510,
 				SimpleImbalance {
-					value: 40259835553610,
+					value: 40258673773030,
 					negative: true
 				}
 			);


### PR DESCRIPTION
Fixes #438 

Fixed #448 

The PR also fixes issue where too much hub asset is burned in remove_liquidity. It should burn only difference between delta_hub and amount which is transferred to LP.

Additional change ensures that a trade can only burn LRNA and returns error when it tries to mint ( to prevent potential bugs if such would occur to avoid erroneous minting).