### PR TITLE
fix: omnipool asset trade state - derive typeinfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "111.0.0"
+version = "112.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",
@@ -6083,7 +6083,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-omnipool"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
@@ -11323,7 +11323,7 @@ dependencies = [
 
 [[package]]
 name = "testing-hydradx-runtime"
-version = "111.0.0"
+version = "112.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",

--- a/pallets/omnipool/Cargo.toml
+++ b/pallets/omnipool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-omnipool"
-version = "1.1.0"
+version = "1.1.1"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"

--- a/pallets/omnipool/src/types.rs
+++ b/pallets/omnipool/src/types.rs
@@ -2,8 +2,6 @@ use super::*;
 use codec::MaxEncodedLen;
 use frame_support::pallet_prelude::*;
 use hydra_dx_math::omnipool::types::{AssetReserveState as MathReserveState, AssetStateChange, BalanceUpdate};
-use scale_info::build::Fields;
-use scale_info::{meta_type, Path, Type, TypeParameter};
 use sp_runtime::{FixedPointNumber, FixedU128};
 use sp_std::ops::{Add, Sub};
 
@@ -15,7 +13,7 @@ pub type Price = FixedU128;
 
 bitflags::bitflags! {
 	/// Indicates whether asset can be bought or sold to/from Omnipool and/or liquidity added/removed.
-	#[derive(Encode,Decode)]
+	#[derive(Encode,Decode, MaxEncodedLen, TypeInfo)]
 	pub struct Tradability: u8 {
 		/// Asset is frozen. No operations are allowed.
 		const FROZEN = 0b0000_0000;
@@ -33,23 +31,6 @@ bitflags::bitflags! {
 impl Default for Tradability {
 	fn default() -> Self {
 		Tradability::SELL | Tradability::BUY | Tradability::ADD_LIQUIDITY | Tradability::REMOVE_LIQUIDITY
-	}
-}
-
-impl MaxEncodedLen for Tradability {
-	fn max_encoded_len() -> usize {
-		u8::max_encoded_len()
-	}
-}
-
-impl TypeInfo for Tradability {
-	type Identity = Self;
-
-	fn type_info() -> Type {
-		Type::builder()
-			.path(Path::new("BitFlags", module_path!()))
-			.type_params(vec![TypeParameter::new("T", Some(meta_type::<Tradability>()))])
-			.composite(Fields::unnamed().field(|f| f.ty::<u64>().type_name("Tradability")))
 	}
 }
 

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "111.0.0"
+version = "112.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 111,
+	spec_version: 112,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/testing-hydradx/Cargo.toml
+++ b/runtime/testing-hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testing-hydradx-runtime"
-version = "111.0.0"
+version = "112.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/testing-hydradx/src/lib.rs
+++ b/runtime/testing-hydradx/src/lib.rs
@@ -110,7 +110,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("testing-hydradx"),
 	impl_name: create_runtime_str!("testing-hydradx"),
 	authoring_version: 1,
-	spec_version: 111,
+	spec_version: 112,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Derive TypeInfo instead of implementing it manually as that did not work correctly.