### PR TITLE
chore: remove nft pallet from runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "112.0.0"
+version = "113.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",
@@ -3341,7 +3341,6 @@ dependencies = [
  "pallet-genesis-history",
  "pallet-identity",
  "pallet-multisig",
- "pallet-nft",
  "pallet-omnipool",
  "pallet-preimage",
  "pallet-proxy",
@@ -5974,25 +5973,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
-]
-
-[[package]]
-name = "pallet-nft"
-version = "4.0.0"
-source = "git+https://github.com/galacticcouncil/warehouse?branch=polkadot-v0.9.28#2dc34f6d99a6c66f56ce89c507eed48d821a21fd"
-dependencies = [
- "frame-support",
- "frame-system",
- "hydradx-traits",
- "orml-utilities",
- "pallet-uniques",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "syn",
 ]
 
 [[package]]
@@ -8717,7 +8697,6 @@ dependencies = [
  "pallet-currencies",
  "pallet-democracy",
  "pallet-elections-phragmen",
- "pallet-nft",
  "pallet-price-oracle",
  "pallet-scheduler",
  "pallet-session",
@@ -11323,7 +11302,7 @@ dependencies = [
 
 [[package]]
 name = "testing-hydradx-runtime"
-version = "112.0.0"
+version = "113.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",
@@ -11366,7 +11345,6 @@ dependencies = [
  "pallet-genesis-history",
  "pallet-identity",
  "pallet-multisig",
- "pallet-nft",
  "pallet-omnipool",
  "pallet-preimage",
  "pallet-proxy",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -17,7 +17,6 @@ pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", 
 hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", branch = "polkadot-v0.9.28", default-features = false }
 pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", branch = "polkadot-v0.9.28", default-features = false}
 pallet-price-oracle = { git = "https://github.com/galacticcouncil/warehouse", branch = "polkadot-v0.9.28", default-features = false}
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", branch = "polkadot-v0.9.28", default-features = false }
 pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", branch = "polkadot-v0.9.28", default-features = false }
 
 pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
@@ -126,7 +125,6 @@ std = [
     "pallet-aura/std",
     "pallet-balances/std",
     "pallet-elections-phragmen/std",
-    "pallet-nft/std",
     "pallet-session/std",
     "pallet-sudo/std",
     "pallet-timestamp/std",

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "112.0.0"
+version = "113.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"
@@ -55,7 +55,6 @@ pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/w
 pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", branch = "polkadot-v0.9.28", default-features = false}
 pallet-collator-rewards = { git = "https://github.com/galacticcouncil/warehouse", branch = "polkadot-v0.9.28", default-features = false}
 pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", branch = "polkadot-v0.9.28", default-features = false}
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", branch = "polkadot-v0.9.28", default-features = false}
 
 # ORML dependencies
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.28", default-features = false }

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -55,7 +55,7 @@ use frame_support::{
 use hydradx_traits::pools::SpotPriceProvider;
 use pallet_transaction_multi_payment::{AddTxAssetOnAccount, DepositAll, RemoveTxAssetOnKilled, TransferFees};
 use pallet_transaction_payment::TargetedFeeAdjustment;
-use primitives::Price;
+use primitives::{CollectionId, ItemId, Price};
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_runtime::traits::BlockNumberProvider;
 
@@ -69,7 +69,6 @@ pub use hex_literal::hex;
 /// Import HydraDX pallets
 pub use pallet_claims;
 pub use pallet_genesis_history;
-use pallet_nft::{CollectionId, ItemId};
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
 /// the specifics of the runtime. They can then be made to be agnostic over specific formats
@@ -98,7 +97,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 112,
+	spec_version: 113,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -186,7 +185,6 @@ impl Contains<Call> for TransfersDisabled {
 			Call::PolkadotXcm(_) => false,
 			Call::OrmlXcm(_) => false,
 			Call::Uniques(_) => false,
-			Call::NFT(_) => false,
 			_ => true,
 		}
 	}
@@ -803,21 +801,6 @@ impl pallet_uniques::Config for Runtime {
 }
 
 parameter_types! {
-	pub ReserveCollectionIdUpTo: u128 = 999_999;
-}
-
-impl pallet_nft::Config for Runtime {
-	type Event = Event;
-	type WeightInfo = pallet_nft::weights::BasiliskWeight<Runtime>;
-	type NftCollectionId = CollectionId;
-	type NftItemId = ItemId;
-	type ProtocolOrigin = EnsureRoot<AccountId>;
-	type CollectionType = pallet_nft::CollectionType;
-	type Permissions = pallet_nft::NftPermissions;
-	type ReserveCollectionIdUpTo = ReserveCollectionIdUpTo;
-}
-
-parameter_types! {
 	pub const LRNA: AssetId = 1;
 	pub const StableAssetId: AssetId = 2;
 	pub ProtofolFee: Permill = Permill::from_rational(3u32,1000u32);
@@ -849,7 +832,7 @@ impl pallet_omnipool::Config for Runtime {
 	type MaxOutRatio = MaxOutRatio;
 	type PositionItemId = ItemId;
 	type NFTCollectionId = OmnipoolCollectionId;
-	type NFTHandler = NFT;
+	type NFTHandler = Uniques;
 	type WeightInfo = ();
 }
 
@@ -883,7 +866,6 @@ construct_runtime!(
 		Claims: pallet_claims = 53,
 		GenesisHistory: pallet_genesis_history = 55,
 		CollatorRewards: pallet_collator_rewards = 57,
-		NFT: pallet_nft = 58,
 		Omnipool: pallet_omnipool = 59,
 
 		// ORML related modules

--- a/runtime/testing-hydradx/Cargo.toml
+++ b/runtime/testing-hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testing-hydradx-runtime"
-version = "112.0.0"
+version = "113.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"
@@ -55,7 +55,6 @@ pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/w
 pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", branch = "polkadot-v0.9.28", default-features = false}
 pallet-collator-rewards = { git = "https://github.com/galacticcouncil/warehouse", branch = "polkadot-v0.9.28", default-features = false}
 pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", branch = "polkadot-v0.9.28", default-features = false}
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", branch = "polkadot-v0.9.28", default-features = false}
 
 # ORML dependencies
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.28", default-features = false }

--- a/runtime/testing-hydradx/src/lib.rs
+++ b/runtime/testing-hydradx/src/lib.rs
@@ -110,7 +110,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("testing-hydradx"),
 	impl_name: create_runtime_str!("testing-hydradx"),
 	authoring_version: 1,
-	spec_version: 112,
+	spec_version: 113,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -786,21 +786,6 @@ impl pallet_uniques::Config for Runtime {
 }
 
 parameter_types! {
-	pub ReserveCollectionIdUpTo: u128 = 999_999;
-}
-
-impl pallet_nft::Config for Runtime {
-	type Event = Event;
-	type WeightInfo = pallet_nft::weights::BasiliskWeight<Runtime>;
-	type NftCollectionId = CollectionId;
-	type NftItemId = ItemId;
-	type ProtocolOrigin = EnsureRoot<AccountId>;
-	type CollectionType = pallet_nft::CollectionType;
-	type Permissions = pallet_nft::NftPermissions;
-	type ReserveCollectionIdUpTo = ReserveCollectionIdUpTo;
-}
-
-parameter_types! {
 	pub const LRNA: AssetId = 1;
 	pub const StableAssetId: AssetId = 2;
 	pub ProtofolFee: Permill = Permill::from_rational(3u32,1000u32);
@@ -832,7 +817,7 @@ impl pallet_omnipool::Config for Runtime {
 	type MaxOutRatio = MaxOutRatio;
 	type PositionItemId = ItemId;
 	type NFTCollectionId = OmnipoolCollectionId;
-	type NFTHandler = NFT;
+	type NFTHandler = Uniques;
 	type WeightInfo = ();
 }
 
@@ -866,7 +851,6 @@ construct_runtime!(
 		Claims: pallet_claims = 53,
 		GenesisHistory: pallet_genesis_history = 55,
 		CollatorRewards: pallet_collator_rewards = 57,
-		NFT: pallet_nft = 58,
 		Omnipool: pallet_omnipool = 59,
 
 		// ORML related modules


### PR DESCRIPTION
This PR removes nft pallet from runtime. 

Omnipool uses Uniques directly. 