### PR TITLE
feat: make omnipool's tvl cap stored value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8748,7 +8748,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "124.0.0"
+version = "125.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-omnipool"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
@@ -11403,7 +11403,7 @@ dependencies = [
 
 [[package]]
 name = "testing-hydradx-runtime"
-version = "124.0.0"
+version = "125.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "0.1.7"
+version = "0.1.8"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/non_native_fee.rs
+++ b/integration-tests/src/non_native_fee.rs
@@ -54,6 +54,11 @@ fn non_native_fee_payment_works_with_omnipool_spot_price() {
 		let stable_price = FixedU128::from_inner(45_000_000_000);
 		hydradx_runtime::Omnipool::protocol_account();
 
+		assert_ok!(hydradx_runtime::Omnipool::set_tvl_cap(
+			hydradx_runtime::Origin::root(),
+			222_222_000_000_000_000_000_000,
+		));
+
 		assert_ok!(hydradx_runtime::Omnipool::initialize_pool(
 			hydradx_runtime::Origin::root(),
 			stable_price,

--- a/integration-tests/src/omnipool_init.rs
+++ b/integration-tests/src/omnipool_init.rs
@@ -21,6 +21,11 @@ fn omnipool_launch_init_params_should_be_correct() {
 		let native_price = FixedU128::from_inner(1201500000000000);
 		let stable_price = FixedU128::from_inner(45_000_000_000);
 
+		assert_ok!(hydradx_runtime::Omnipool::set_tvl_cap(
+			hydradx_runtime::Origin::root(),
+			222_222_000_000_000_000_000_000,
+		));
+
 		assert_ok!(hydradx_runtime::Omnipool::initialize_pool(
 			hydradx_runtime::Origin::root(),
 			stable_price,

--- a/pallets/omnipool/Cargo.toml
+++ b/pallets/omnipool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-omnipool"
-version = "1.3.2"
+version = "1.4.0"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"

--- a/pallets/omnipool/src/benchmarks.rs
+++ b/pallets/omnipool/src/benchmarks.rs
@@ -26,6 +26,8 @@ use frame_benchmarking::benchmarks;
 use frame_system::RawOrigin;
 use orml_traits::MultiCurrencyExtended;
 
+const TVL_CAP: Balance = 222_222_000_000_000_000_000_000;
+
 benchmarks! {
 	 where_clause {  where T::AssetId: From<u32>,
 		T::Currency: MultiCurrencyExtended<T::AccountId, Amount=i128>,
@@ -39,6 +41,8 @@ benchmarks! {
 		let native_price: FixedU128= FixedU128::from(1);
 
 		let acc = crate::Pallet::<T>::protocol_account();
+
+		crate::Pallet::<T>::set_tvl_cap(RawOrigin::Root.into(), TVL_CAP)?;
 
 		T::Currency::update_balance(T::StableCoinAssetId::get(), &acc, stable_amount as i128)?;
 		T::Currency::update_balance(T::HdxAssetId::get(), &acc, native_amount as i128)?;
@@ -56,6 +60,8 @@ benchmarks! {
 		let stable_price: FixedU128= FixedU128::from((1,2));
 		let native_price: FixedU128= FixedU128::from(1);
 		let acc = crate::Pallet::<T>::protocol_account();
+
+		crate::Pallet::<T>::set_tvl_cap(RawOrigin::Root.into(), TVL_CAP)?;
 
 		T::Currency::update_balance(T::StableCoinAssetId::get(), &acc, stable_amount as i128)?;
 		T::Currency::update_balance(T::HdxAssetId::get(), &acc, native_amount as i128)?;
@@ -88,6 +94,8 @@ benchmarks! {
 		let stable_price: FixedU128= FixedU128::from((1,2));
 		let native_price: FixedU128= FixedU128::from(1);
 		let acc = crate::Pallet::<T>::protocol_account();
+
+		crate::Pallet::<T>::set_tvl_cap(RawOrigin::Root.into(), TVL_CAP)?;
 
 		T::Currency::update_balance(T::StableCoinAssetId::get(), &acc, stable_amount as i128)?;
 		T::Currency::update_balance(T::HdxAssetId::get(), &acc, native_amount as i128)?;
@@ -128,6 +136,8 @@ benchmarks! {
 		let stable_price: FixedU128= FixedU128::from((1,2));
 		let native_price: FixedU128= FixedU128::from(1);
 		let acc = crate::Pallet::<T>::protocol_account();
+
+		crate::Pallet::<T>::set_tvl_cap(RawOrigin::Root.into(), TVL_CAP)?;
 
 		T::Currency::update_balance(T::StableCoinAssetId::get(), &acc, stable_amount as i128)?;
 		T::Currency::update_balance(T::HdxAssetId::get(), &acc, native_amount as i128)?;
@@ -180,6 +190,8 @@ benchmarks! {
 		let native_price: FixedU128= FixedU128::from(1);
 		let acc = crate::Pallet::<T>::protocol_account();
 
+		crate::Pallet::<T>::set_tvl_cap(RawOrigin::Root.into(), TVL_CAP)?;
+
 		T::Currency::update_balance(T::StableCoinAssetId::get(), &acc, stable_amount as i128)?;
 		T::Currency::update_balance(T::HdxAssetId::get(), &acc, native_amount as i128)?;
 
@@ -231,6 +243,8 @@ benchmarks! {
 		let stable_price: FixedU128= FixedU128::from((1,2));
 		let native_price: FixedU128= FixedU128::from(1);
 		let acc = crate::Pallet::<T>::protocol_account();
+
+		crate::Pallet::<T>::set_tvl_cap(RawOrigin::Root.into(), TVL_CAP)?;
 
 		T::Currency::update_balance(T::StableCoinAssetId::get(), &acc, stable_amount as i128)?;
 		T::Currency::update_balance(T::HdxAssetId::get(), &acc, native_amount as i128)?;
@@ -285,6 +299,8 @@ benchmarks! {
 
 		let acc = crate::Pallet::<T>::protocol_account();
 
+		crate::Pallet::<T>::set_tvl_cap(RawOrigin::Root.into(), TVL_CAP)?;
+
 		T::Currency::update_balance(T::StableCoinAssetId::get(), &acc, stable_amount as i128)?;
 		T::Currency::update_balance(T::HdxAssetId::get(), &acc, native_amount as i128)?;
 
@@ -316,6 +332,8 @@ benchmarks! {
 		let stable_price: FixedU128= FixedU128::from((1,2));
 		let native_price: FixedU128= FixedU128::from(1);
 		let acc = crate::Pallet::<T>::protocol_account();
+
+		crate::Pallet::<T>::set_tvl_cap(RawOrigin::Root.into(), TVL_CAP)?;
 
 		T::Currency::update_balance(T::StableCoinAssetId::get(), &acc, stable_amount as i128)?;
 		T::Currency::update_balance(T::HdxAssetId::get(), &acc, native_amount as i128)?;
@@ -359,6 +377,8 @@ benchmarks! {
 		let native_price: FixedU128 = FixedU128::from(1);
 
 		let acc = crate::Pallet::<T>::protocol_account();
+
+		crate::Pallet::<T>::set_tvl_cap(RawOrigin::Root.into(), TVL_CAP)?;
 
 		T::Currency::update_balance(T::StableCoinAssetId::get(), &acc, stable_amount as i128)?;
 		T::Currency::update_balance(T::HdxAssetId::get(), &acc, native_amount as i128)?;

--- a/pallets/omnipool/src/lib.rs
+++ b/pallets/omnipool/src/lib.rs
@@ -297,6 +297,9 @@ pub mod pallet {
 
 		/// Asset's weight cap has been updated.
 		AssetWeightCapUpdated { asset_id: T::AssetId, cap: Permill },
+
+		/// TVL cap has been updated.
+		TVLCapUpdated { cap: Balance },
 	}
 
 	#[pallet::error]
@@ -1317,13 +1320,14 @@ pub mod pallet {
 		/// Parameters:
 		/// - `cap`: new tvl cap
 		///
-		/// Emits `AssetWeightCapUpdated` event when successful.
+		/// Emits `TVLCapUpdated` event when successful.
 		///
 		#[pallet::weight(<T as Config>::WeightInfo::set_asset_weight_cap())]
 		#[transactional]
 		pub fn set_tvl_cap(origin: OriginFor<T>, cap: Balance) -> DispatchResult {
 			T::AddTokenOrigin::ensure_origin(origin)?;
 			TvlCap::<T>::set(cap);
+			Self::deposit_event(Event::TVLCapUpdated { cap });
 			Ok(())
 		}
 	}

--- a/pallets/omnipool/src/lib.rs
+++ b/pallets/omnipool/src/lib.rs
@@ -134,8 +134,8 @@ pub mod pallet {
 		/// Multi currency mechanism
 		type Currency: MultiCurrency<Self::AccountId, CurrencyId = Self::AssetId, Balance = Balance>;
 
-		/// Add token origin
-		type AddTokenOrigin: EnsureOrigin<Self::Origin>;
+		/// Origin that can add token, refund refused asset and  set tvl cap.
+		type AuthorityOrigin: EnsureOrigin<Self::Origin>;
 
 		/// Origin to be able to suspend asset trades and initialize Omnipool.
 		type TechnicalOrigin: EnsureOrigin<Self::Origin>;
@@ -503,7 +503,7 @@ pub mod pallet {
 			weight_cap: Permill,
 			position_owner: T::AccountId,
 		) -> DispatchResult {
-			T::AddTokenOrigin::ensure_origin(origin)?;
+			T::AuthorityOrigin::ensure_origin(origin)?;
 
 			ensure!(!Assets::<T>::contains_key(asset), Error::<T>::AssetAlreadyAdded);
 
@@ -1258,7 +1258,7 @@ pub mod pallet {
 		///
 		/// Transfer is performed only when asset is not in Omnipool and pool's balance has sufficient amount.
 		///
-		/// Only `AddTokenOrigin` can perform this operition -same as `add_token`o
+		/// Only `AuthorityOrigin` can perform this operition -same as `add_token`o
 		///
 		/// Emits `AssetRefunded`
 		#[pallet::weight(<T as Config>::WeightInfo::refund_refused_asset())]
@@ -1269,7 +1269,7 @@ pub mod pallet {
 			amount: Balance,
 			recipient: T::AccountId,
 		) -> DispatchResult {
-			T::AddTokenOrigin::ensure_origin(origin)?;
+			T::AuthorityOrigin::ensure_origin(origin)?;
 
 			// Hub asset cannot be refunded
 			ensure!(asset_id != T::HubAssetId::get(), Error::<T>::AssetRefundNotAllowed);
@@ -1325,7 +1325,7 @@ pub mod pallet {
 		#[pallet::weight(<T as Config>::WeightInfo::set_asset_weight_cap())]
 		#[transactional]
 		pub fn set_tvl_cap(origin: OriginFor<T>, cap: Balance) -> DispatchResult {
-			T::AddTokenOrigin::ensure_origin(origin)?;
+			T::AuthorityOrigin::ensure_origin(origin)?;
 			TvlCap::<T>::set(cap);
 			Self::deposit_event(Event::TVLCapUpdated { cap });
 			Ok(())

--- a/pallets/omnipool/src/tests/invariants.rs
+++ b/pallets/omnipool/src/tests/invariants.rs
@@ -934,7 +934,7 @@ proptest! {
 				let stable_reserve = Tokens::free_balance(DAI, &Omnipool::protocol_account());
 
 				let global_tvl = hydra_dx_math::omnipool::calculate_tvl(hub_reserve, (stable_reserve, stable_asset.hub_reserve)).unwrap();
-				assert!( global_tvl <= <Test as Config>::TVLCap::get());
+				assert!( global_tvl <= TvlCap::<Test>::get());
 			});
 	}
 }
@@ -1031,7 +1031,7 @@ proptest! {
 				let stable_reserve = Tokens::free_balance(DAI, &Omnipool::protocol_account());
 
 				let global_tvl = hydra_dx_math::omnipool::calculate_tvl(hub_reserve, (stable_reserve, stable_asset.hub_reserve)).unwrap();
-				assert!( global_tvl <= <Test as Config>::TVLCap::get());
+				assert!( global_tvl <= TvlCap::<Test>::get());
 			});
 	}
 }

--- a/pallets/omnipool/src/tests/mock.rs
+++ b/pallets/omnipool/src/tests/mock.rs
@@ -164,7 +164,7 @@ impl Config for Test {
 	type AssetId = AssetId;
 	type PositionItemId = u32;
 	type Currency = Tokens;
-	type AddTokenOrigin = EnsureRoot<Self::AccountId>;
+	type AuthorityOrigin = EnsureRoot<Self::AccountId>;
 	type HubAssetId = LRNAAssetId;
 	type ProtocolFee = ProtocolFee;
 	type AssetFee = AssetFee;

--- a/pallets/omnipool/src/tests/tvl.rs
+++ b/pallets/omnipool/src/tests/tvl.rs
@@ -102,3 +102,72 @@ fn remove_liquidity_should_work_when_tvl_is_reached() {
 			),);
 		});
 }
+
+#[test]
+fn set_tvl_cap_should_work() {
+	let stable_amount = 50_000 * ONE * 1_000_000;
+	let native_amount = 936_329_588_000_000_000u128;
+	let dot_amount = 87_719_298_250_000_u128;
+
+	let native_price = FixedU128::from_inner(1201500000000000);
+	let stable_price = FixedU128::from_inner(45_000_000_000);
+	let token_price = FixedU128::from_inner(25_650_000_000_000_000_000);
+
+	let dot_id = 1_000;
+
+	ExtBuilder::default()
+		.with_endowed_accounts(vec![
+			(Omnipool::protocol_account(), DAI, stable_amount),
+			(Omnipool::protocol_account(), HDX, native_amount),
+			(LP1, DAI, 200_000 * ONE * 1_000_000),
+			(LP2, dot_id, dot_amount),
+			(LP2, DAI, 20_000 * ONE * 1_000_000),
+		])
+		.with_registered_asset(dot_id)
+		.with_initial_pool(stable_price, native_price)
+		.with_token(1_000, token_price, LP2, dot_amount)
+		.with_tvl_cap(222_222 * ONE * 1_000_000)
+		.build()
+		.execute_with(|| {
+			assert_eq!(TvlCap::<Test>::get(), 222_222 * ONE * 1_000_000);
+
+			assert_ok!(Omnipool::set_tvl_cap(Origin::root(), u128::MAX));
+
+			assert_eq!(TvlCap::<Test>::get(), u128::MAX);
+		});
+}
+
+#[test]
+fn set_tvl_cap_should_fail_when_not_root_origin() {
+	let stable_amount = 50_000 * ONE * 1_000_000;
+	let native_amount = 936_329_588_000_000_000u128;
+	let dot_amount = 87_719_298_250_000_u128;
+
+	let native_price = FixedU128::from_inner(1201500000000000);
+	let stable_price = FixedU128::from_inner(45_000_000_000);
+	let token_price = FixedU128::from_inner(25_650_000_000_000_000_000);
+
+	let dot_id = 1_000;
+
+	ExtBuilder::default()
+		.with_endowed_accounts(vec![
+			(Omnipool::protocol_account(), DAI, stable_amount),
+			(Omnipool::protocol_account(), HDX, native_amount),
+			(LP1, DAI, 200_000 * ONE * 1_000_000),
+			(LP2, dot_id, dot_amount),
+			(LP2, DAI, 20_000 * ONE * 1_000_000),
+		])
+		.with_registered_asset(dot_id)
+		.with_initial_pool(stable_price, native_price)
+		.with_token(1_000, token_price, LP2, dot_amount)
+		.with_tvl_cap(222_222 * ONE * 1_000_000)
+		.build()
+		.execute_with(|| {
+			assert_eq!(TvlCap::<Test>::get(), 222_222 * ONE * 1_000_000);
+
+			assert_noop!(
+				Omnipool::set_tvl_cap(Origin::signed(LP1), u128::MAX),
+				sp_runtime::traits::BadOrigin,
+			);
+		});
+}

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "124.0.0"
+version = "125.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -97,7 +97,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 124,
+	spec_version: 125,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -806,7 +806,6 @@ parameter_types! {
 	pub const StableAssetId: AssetId = 2;
 	pub ProtocolFee: Permill = Permill::from_rational(5u32,10000u32);
 	pub AssetFee: Permill = Permill::from_rational(25u32,10000u32);
-	pub const TVLCap : Balance = 222_222_000_000_000_000_000_000u128;
 	pub const MinTradingLimit : Balance = 1_000_000u128;
 	pub const MinPoolLiquidity: Balance = 1_000_000u128;
 	pub const MaxInRatio: Balance = 3u128;
@@ -826,7 +825,6 @@ impl pallet_omnipool::Config for Runtime {
 	type StableCoinAssetId = StableAssetId;
 	type ProtocolFee = ProtocolFee;
 	type AssetFee = AssetFee;
-	type TVLCap = TVLCap;
 	type MinimumTradingLimit = MinTradingLimit;
 	type MinimumPoolLiquidity = MinPoolLiquidity;
 	type MaxInRatio = MaxInRatio;

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -817,7 +817,7 @@ impl pallet_omnipool::Config for Runtime {
 	type Event = Event;
 	type AssetId = AssetId;
 	type Currency = Currencies;
-	type AddTokenOrigin = EnsureRoot<AccountId>;
+	type AuthorityOrigin = EnsureRoot<AccountId>;
 	type TechnicalOrigin = SuperMajorityTechCommittee;
 	type AssetRegistry = AssetRegistry;
 	type HdxAssetId = NativeAssetId;

--- a/runtime/testing-hydradx/Cargo.toml
+++ b/runtime/testing-hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testing-hydradx-runtime"
-version = "124.0.0"
+version = "125.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/testing-hydradx/src/lib.rs
+++ b/runtime/testing-hydradx/src/lib.rs
@@ -108,7 +108,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("testing-hydradx"),
 	impl_name: create_runtime_str!("testing-hydradx"),
 	authoring_version: 1,
-	spec_version: 124,
+	spec_version: 125,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -807,7 +807,6 @@ parameter_types! {
 	pub const StableAssetId: AssetId = 2;
 	pub ProtocolFee: Permill = Permill::from_rational(5u32,10000u32);
 	pub AssetFee: Permill = Permill::from_rational(25u32,10000u32);
-	pub const TVLCap : Balance = 222_222_000_000_000_000_000_000u128;
 	pub const MinTradingLimit : Balance = 1_000_000u128;
 	pub const MinPoolLiquidity: Balance = 1_000_000u128;
 	pub const MaxInRatio: Balance = 3u128;
@@ -827,7 +826,6 @@ impl pallet_omnipool::Config for Runtime {
 	type StableCoinAssetId = StableAssetId;
 	type ProtocolFee = ProtocolFee;
 	type AssetFee = AssetFee;
-	type TVLCap = TVLCap;
 	type MinimumTradingLimit = MinTradingLimit;
 	type MinimumPoolLiquidity = MinPoolLiquidity;
 	type MaxInRatio = MaxInRatio;

--- a/runtime/testing-hydradx/src/lib.rs
+++ b/runtime/testing-hydradx/src/lib.rs
@@ -818,7 +818,7 @@ impl pallet_omnipool::Config for Runtime {
 	type Event = Event;
 	type AssetId = AssetId;
 	type Currency = Currencies;
-	type AddTokenOrigin = EnsureRoot<AccountId>;
+	type AuthorityOrigin = EnsureRoot<AccountId>;
 	type TechnicalOrigin = SuperMajorityTechCommittee;
 	type AssetRegistry = AssetRegistry;
 	type HdxAssetId = NativeAssetId;


### PR DESCRIPTION
This PR removes TVL cap constant from pallet's config and introduces TVL cap as stored value.

This value can be changed using set_tvl_cap extrinsic. 