### PR TITLE
ci: missing artifact

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: build-and-deploy
 on:
   push:
     branches:
+      - master
       - hydra-parachain
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
`test-upgrade-runtime` job fails because it's unable to locate an artifact. The job requires the binary uploaded from the `master` branch.