### PR TITLE
chore: update to latest warehouse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3345,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "hydradx-adapters"
 version = "0.2.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=b7cc6ff5efb641e4fd4da524459ce8111c32aef5#b7cc6ff5efb641e4fd4da524459ce8111c32aef5"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=89f1614e9213889222ce1b991bdf31f54a5597da#89f1614e9213889222ce1b991bdf31f54a5597da"
 dependencies = [
  "frame-support",
  "hydradx-traits",
@@ -3451,8 +3451,8 @@ dependencies = [
 
 [[package]]
 name = "hydradx-traits"
-version = "0.9.0"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=b7cc6ff5efb641e4fd4da524459ce8111c32aef5#b7cc6ff5efb641e4fd4da524459ce8111c32aef5"
+version = "1.0.0"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=89f1614e9213889222ce1b991bdf31f54a5597da#89f1614e9213889222ce1b991bdf31f54a5597da"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -5518,8 +5518,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-registry"
-version = "1.3.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=b7cc6ff5efb641e4fd4da524459ce8111c32aef5#b7cc6ff5efb641e4fd4da524459ce8111c32aef5"
+version = "2.0.1"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=89f1614e9213889222ce1b991bdf31f54a5597da#89f1614e9213889222ce1b991bdf31f54a5597da"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5748,7 +5748,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-rewards"
 version = "1.0.3"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=b7cc6ff5efb641e4fd4da524459ce8111c32aef5#b7cc6ff5efb641e4fd4da524459ce8111c32aef5"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=89f1614e9213889222ce1b991bdf31f54a5597da#89f1614e9213889222ce1b991bdf31f54a5597da"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5804,7 +5804,7 @@ dependencies = [
 [[package]]
 name = "pallet-currencies"
 version = "1.0.1"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=b7cc6ff5efb641e4fd4da524459ce8111c32aef5#b7cc6ff5efb641e4fd4da524459ce8111c32aef5"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=89f1614e9213889222ce1b991bdf31f54a5597da#89f1614e9213889222ce1b991bdf31f54a5597da"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6221,7 +6221,7 @@ dependencies = [
 [[package]]
 name = "pallet-relaychain-info"
 version = "0.3.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=b7cc6ff5efb641e4fd4da524459ce8111c32aef5#b7cc6ff5efb641e4fd4da524459ce8111c32aef5"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=89f1614e9213889222ce1b991bdf31f54a5597da#89f1614e9213889222ce1b991bdf31f54a5597da"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -6396,8 +6396,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-multi-payment"
-version = "8.0.3"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=b7cc6ff5efb641e4fd4da524459ce8111c32aef5#b7cc6ff5efb641e4fd4da524459ce8111c32aef5"
+version = "8.0.4"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=89f1614e9213889222ce1b991bdf31f54a5597da#89f1614e9213889222ce1b991bdf31f54a5597da"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6415,7 +6415,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-pause"
 version = "0.1.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=b7cc6ff5efb641e4fd4da524459ce8111c32aef5#b7cc6ff5efb641e4fd4da524459ce8111c32aef5"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=89f1614e9213889222ce1b991bdf31f54a5597da#89f1614e9213889222ce1b991bdf31f54a5597da"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -13,10 +13,10 @@ primitives = { default-features = false, path = "../primitives" }
 hydradx-runtime = { path = "../runtime/hydradx", default-features = true}
 
 # HydraDX dependencies
-pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false }
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false}
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse",rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false}
+pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false}
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse",rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false}
 
 pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
 pallet-democracy = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
@@ -98,7 +98,7 @@ polkadot-runtime = { git = "https://github.com/paritytech/polkadot", branch = "r
 [dev-dependencies]
 hex-literal = "0.3.1"
 pretty_assertions = "1.2.1"
-pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5" }
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da" }
 xcm-emulator = { git = "https://github.com/shaunxw/xcm-simulator", rev = "0460d04c798028e7bef82c907082e11753ed173b" }
 
 [features]

--- a/integration-tests/src/polkadot_test_net.rs
+++ b/integration-tests/src/polkadot_test_net.rs
@@ -179,6 +179,11 @@ pub fn hydra_ext() -> sp_io::TestExternalities {
 			(b"DAI".to_vec(), 1_000u128),
 			(b"USDC".to_vec(), 1_000u128),
 		],
+		asset_ids: vec![
+			(b"LRNA".to_vec(), 1_000u128, LRNA),
+			(b"DAI".to_vec(), 1_000u128, DAI),
+			(b"USDC".to_vec(), 1_000u128, DOT),
+		],
 		native_asset_name: b"HDX".to_vec(),
 		native_existential_deposit: existential_deposit,
 	}

--- a/node/src/chain_spec/local.rs
+++ b/node/src/chain_spec/local.rs
@@ -81,6 +81,7 @@ pub fn parachain_config() -> Result<ChainSpec, String> {
 				vec![],
 				// registered assets
 				vec![(b"KSM".to_vec(), 1_000u128), (b"KUSD".to_vec(), 1_000u128)],
+				vec![(b"KSM".to_vec(), 1_000u128, 1u32), (b"KUSD".to_vec(), 1_000u128, 2u32)],
 				// accepted assets
 				vec![(1, Price::from_float(0.0000212)), (2, Price::from_float(0.000806))],
 				// token balances

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -93,6 +93,7 @@ pub fn parachain_genesis(
 	tech_committee_members: Vec<AccountId>,
 	vesting_list: Vec<(AccountId, BlockNumber, BlockNumber, u32, Balance)>,
 	registered_assets: Vec<(Vec<u8>, Balance)>, // (Asset name, Existential deposit)
+	registered_ids: Vec<(Vec<u8>, Balance, AssetId)>, // (Asset name, Existential deposit, Chosen asset id)
 	accepted_assets: Vec<(AssetId, Price)>,     // (Asset id, Fallback price) - asset which fee can be paid with
 	token_balances: Vec<(AccountId, Vec<(AssetId, Balance)>)>,
 	claims_data: Vec<(EthereumAddress, Balance)>,
@@ -142,6 +143,7 @@ pub fn parachain_genesis(
 		vesting: VestingConfig { vesting: vesting_list },
 		asset_registry: AssetRegistryConfig {
 			asset_names: registered_assets.clone(),
+			asset_ids: registered_ids,
 			native_asset_name: TOKEN_SYMBOL.as_bytes().to_vec(),
 			native_existential_deposit: NATIVE_EXISTENTIAL_DEPOSIT,
 		},

--- a/node/src/chain_spec/rococo.rs
+++ b/node/src/chain_spec/rococo.rs
@@ -80,6 +80,7 @@ pub fn _parachain_config_rococo() -> Result<ChainSpec, String> {
 				vec![],
 				// registered_assets
 				vec![],
+				vec![],
 				// accepted_assets
 				vec![],
 				// token balances

--- a/node/src/chain_spec/staging.rs
+++ b/node/src/chain_spec/staging.rs
@@ -74,6 +74,7 @@ pub fn parachain_config() -> Result<ChainSpec, String> {
 				vec![],
 				// registered_assets
 				vec![],
+				vec![],
 				// accepted_assets
 				vec![],
 				// token balances

--- a/node/src/testing_chain_spec.rs
+++ b/node/src/testing_chain_spec.rs
@@ -141,6 +141,7 @@ pub fn local_parachain_config() -> Result<ChainSpec, String> {
 				],
 				vec![],
 				vec![(b"KSM".to_vec(), 1_000u128), (b"KUSD".to_vec(), 1_000u128)],
+				vec![(b"KSM".to_vec(), 1_000u128, 1u32), (b"KUSD".to_vec(), 1_000u128, 2u32)],
 				vec![(1, Price::from_float(0.0000212)), (2, Price::from_float(0.000806))],
 				vec![
 					(
@@ -246,6 +247,7 @@ pub fn devnet_parachain_config() -> Result<ChainSpec, String> {
 				vec![],
 				// registered_assets
 				vec![],
+				vec![],
 				// accepted_assets
 				vec![],
 				// token balances
@@ -299,6 +301,7 @@ fn testnet_parachain_genesis(
 	tech_committee_members: Vec<AccountId>,
 	vesting_list: Vec<(AccountId, BlockNumber, BlockNumber, u32, Balance)>,
 	registered_assets: Vec<(Vec<u8>, Balance)>, // (Asset name, Existential deposit)
+	registered_ids: Vec<(Vec<u8>, Balance, AssetId)>, // (Asset name, Existential deposit, Chosen asset id)
 	accepted_assets: Vec<(AssetId, Price)>,     // (Asset id, Fallback price) - asset which fee can be paid with
 	token_balances: Vec<(AccountId, Vec<(AssetId, Balance)>)>,
 	claims_data: Vec<(EthereumAddress, Balance)>,
@@ -353,6 +356,7 @@ fn testnet_parachain_genesis(
 		vesting: VestingConfig { vesting: vesting_list },
 		asset_registry: AssetRegistryConfig {
 			asset_names: registered_assets.clone(),
+			asset_ids: registered_ids,
 			native_asset_name: TOKEN_SYMBOL.as_bytes().to_vec(),
 			native_existential_deposit: NATIVE_EXISTENTIAL_DEPOSIT,
 		},

--- a/pallets/omnipool/Cargo.toml
+++ b/pallets/omnipool/Cargo.toml
@@ -29,7 +29,7 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "polk
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }
 
 # Warehouse
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false }
 
 hydra-dx-math = { git = "https://github.com/galacticcouncil/HydraDX-math", rev = "2d7f86ffae242fc855bc833dd22df2d8dc5d03df", default-features = false }
 

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -38,10 +38,10 @@ pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
 
 pallet-claims = { path = '../../pallets/claims', default-features = false }
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false}
-pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse",rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false}
-pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false}
+pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse",rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false}
+pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false }
 
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }
 orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -313,4 +313,5 @@ parameter_types! {
 // pallet asset registry
 parameter_types! {
 	pub const RegistryStrLimit: u32 = 32;
+	pub const SequentialIdOffset: u32 = 1_000_000;
 }

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -48,14 +48,14 @@ pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate", b
 pallet-uniques = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
 
 # Warehouse dependencies
-hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false }
-pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false }
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false}
-pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false }
-pallet-collator-rewards = { git = "https://github.com/galacticcouncil/warehouse",rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false}
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse",rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false}
-pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false }
+hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false }
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false}
+pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false }
+pallet-collator-rewards = { git = "https://github.com/galacticcouncil/warehouse",rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false}
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse",rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false}
+pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false }
 
 # ORML dependencies
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -719,6 +719,7 @@ impl pallet_asset_registry::Config for Runtime {
 	type AssetNativeLocation = AssetLocation;
 	type StringLimit = RegistryStrLimit;
 	type NativeAssetId = NativeAssetId;
+	type SequentialIdStartAt = SequentialIdOffset;
 	type WeightInfo = weights::registry::HydraWeight<Runtime>;
 }
 

--- a/runtime/testing-hydradx/Cargo.toml
+++ b/runtime/testing-hydradx/Cargo.toml
@@ -49,14 +49,14 @@ pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate", b
 pallet-uniques = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
 
 # Warehouse dependencies
-hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false }
-pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false }
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false}
-pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false }
-pallet-collator-rewards = { git = "https://github.com/galacticcouncil/warehouse",rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false}
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse",rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false}
-pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "b7cc6ff5efb641e4fd4da524459ce8111c32aef5", default-features = false }
+hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false }
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false}
+pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false }
+pallet-collator-rewards = { git = "https://github.com/galacticcouncil/warehouse",rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false}
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse",rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false}
+pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "89f1614e9213889222ce1b991bdf31f54a5597da", default-features = false }
 
 
 # ORML dependencies

--- a/runtime/testing-hydradx/src/lib.rs
+++ b/runtime/testing-hydradx/src/lib.rs
@@ -729,6 +729,7 @@ impl pallet_asset_registry::Config for Runtime {
 	type AssetNativeLocation = AssetLocation;
 	type StringLimit = RegistryStrLimit;
 	type NativeAssetId = NativeAssetId;
+	type SequentialIdStartAt = SequentialIdOffset;
 	type WeightInfo = weights::registry::HydraWeight<Runtime>;
 }
 


### PR DESCRIPTION
This PR updates the version of warehouse pallets to the latest.

The most significant change is asset registry which now supports registering assets with given ID. 