### PR TITLE
test: add test to ensure omnipool's imbalance is reduced to 0 correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-omnipool"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "bitflags",
  "frame-benchmarking",

--- a/pallets/omnipool/Cargo.toml
+++ b/pallets/omnipool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-omnipool"
-version = "1.4.2"
+version = "1.4.3"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Adding a test to ensure that after certain amount of trades, imbalance is correctly reduced to 0 and subsequent operations work correctly.