### PR TITLE
fix: potential overflow in get_position_value_in_hub_asset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6237,7 +6237,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-omnipool-liquidity-mining"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bitflags",
  "frame-benchmarking",

--- a/pallets/omnipool-liquidity-mining/Cargo.toml
+++ b/pallets/omnipool-liquidity-mining/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-omnipool-liquidity-mining"
-version = "1.0.0"
+version = "1.0.1"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
This PR changes type in the calculation in `get_token_value_in_hub_asset()` to prevent multiplication overflow.