### PR TITLE
feat: add origin and weight info  to omnipool hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6212,7 +6212,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-omnipool"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "bitflags",
  "frame-benchmarking",

--- a/pallets/omnipool/Cargo.toml
+++ b/pallets/omnipool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-omnipool"
-version = "1.6.0"
+version = "1.6.1"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"

--- a/pallets/omnipool/src/traits.rs
+++ b/pallets/omnipool/src/traits.rs
@@ -44,6 +44,8 @@ where
 		asset_out: AssetInfo<AssetId, Balance>,
 	) -> Result<(), Self::Error>;
 
+	fn on_hub_asset_trade(origin: Origin, asset: AssetInfo<AssetId, Balance>) -> Result<(), Self::Error>;
+
 	fn on_liquidity_changed_weight() -> Weight;
 	fn on_trade_weight() -> Weight;
 }
@@ -59,6 +61,10 @@ where
 	}
 
 	fn on_trade(_: Origin, _: AssetInfo<AssetId, Balance>, _: AssetInfo<AssetId, Balance>) -> Result<(), Self::Error> {
+		Ok(())
+	}
+
+	fn on_hub_asset_trade(_: Origin, _: AssetInfo<AssetId, Balance>) -> Result<(), Self::Error> {
 		Ok(())
 	}
 

--- a/pallets/omnipool/src/traits.rs
+++ b/pallets/omnipool/src/traits.rs
@@ -1,4 +1,5 @@
 use crate::types::AssetReserveState;
+use frame_support::weights::Weight;
 use hydra_dx_math::omnipool::types::AssetStateChange;
 use sp_runtime::DispatchError;
 
@@ -31,29 +32,41 @@ where
 	}
 }
 
-pub trait OmnipoolHooks<AssetId, Balance>
+pub trait OmnipoolHooks<Origin, AssetId, Balance>
 where
 	Balance: Default + Clone,
 {
 	type Error;
-	fn on_liquidity_changed(asset: AssetInfo<AssetId, Balance>) -> Result<(), Self::Error>;
+	fn on_liquidity_changed(origin: Origin, asset: AssetInfo<AssetId, Balance>) -> Result<(), Self::Error>;
 	fn on_trade(
+		origin: Origin,
 		asset_in: AssetInfo<AssetId, Balance>,
 		asset_out: AssetInfo<AssetId, Balance>,
 	) -> Result<(), Self::Error>;
+
+	fn on_liquidity_changed_weight() -> Weight;
+	fn on_trade_weight() -> Weight;
 }
 
-impl<AssetId, Balance> OmnipoolHooks<AssetId, Balance> for ()
+impl<Origin, AssetId, Balance> OmnipoolHooks<Origin, AssetId, Balance> for ()
 where
 	Balance: Default + Clone,
 {
 	type Error = DispatchError;
 
-	fn on_liquidity_changed(_: AssetInfo<AssetId, Balance>) -> Result<(), Self::Error> {
+	fn on_liquidity_changed(_: Origin, _: AssetInfo<AssetId, Balance>) -> Result<(), Self::Error> {
 		Ok(())
 	}
 
-	fn on_trade(_: AssetInfo<AssetId, Balance>, _: AssetInfo<AssetId, Balance>) -> Result<(), Self::Error> {
+	fn on_trade(_: Origin, _: AssetInfo<AssetId, Balance>, _: AssetInfo<AssetId, Balance>) -> Result<(), Self::Error> {
 		Ok(())
+	}
+
+	fn on_liquidity_changed_weight() -> Weight {
+		Weight::zero()
+	}
+
+	fn on_trade_weight() -> Weight {
+		Weight::zero()
 	}
 }


### PR DESCRIPTION
This PR adds origin to omnipool hooks. 

It also includes hook weight in the extrinsic weight

And also adds on_trade to buy ( missed before).