### PR TITLE
fix: circuit breaker weights, events refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6318,7 +6318,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-omnipool"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
@@ -8973,7 +8973,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "102.0.0"
+version = "102.1.0"
 dependencies = [
  "cumulus-pallet-xcmp-queue",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-circuit-breaker"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.5.1"
+version = "1.5.2"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/circuit_breaker.rs
+++ b/integration-tests/src/circuit_breaker.rs
@@ -100,7 +100,7 @@ fn sell_in_omnipool_should_fail_when_max_trade_limit_per_block_exceeded() {
 				sell_amount,
 				min_limit
 			),
-			pallet_circuit_breaker::Error::<hydradx_runtime::Runtime>::MaxTradeVolumePerBlockReached
+			pallet_circuit_breaker::Error::<hydradx_runtime::Runtime>::TokenInfluxLimitReached
 		);
 	});
 }
@@ -142,7 +142,7 @@ fn sell_lrna_in_omnipool_should_fail_when_min_trade_limit_per_block_exceeded() {
 				sell_amount,
 				min_limit
 			),
-			pallet_circuit_breaker::Error::<hydradx_runtime::Runtime>::MinTradeVolumePerBlockReached
+			pallet_circuit_breaker::Error::<hydradx_runtime::Runtime>::TokenOutflowLimitReached
 		);
 	});
 }
@@ -189,7 +189,7 @@ fn buy_asset_for_lrna_should_fail_when_min_trade_limit_per_block_exceeded() {
 				buy_amount + 1,
 				Balance::MAX
 			),
-			pallet_circuit_breaker::Error::<hydradx_runtime::Runtime>::MinTradeVolumePerBlockReached
+			pallet_circuit_breaker::Error::<hydradx_runtime::Runtime>::TokenOutflowLimitReached
 		);
 	});
 }
@@ -249,7 +249,7 @@ fn buy_in_omnipool_should_fail_when_max_trade_limit_per_block_exceeded() {
 				50000 * UNITS,
 				Balance::MAX
 			),
-			pallet_circuit_breaker::Error::<hydradx_runtime::Runtime>::MaxTradeVolumePerBlockReached
+			pallet_circuit_breaker::Error::<hydradx_runtime::Runtime>::TokenInfluxLimitReached
 		);
 	});
 }

--- a/integration-tests/src/circuit_breaker.rs
+++ b/integration-tests/src/circuit_breaker.rs
@@ -97,22 +97,27 @@ fn sell_lrna_in_omnipool_should_fail_when_min_trade_limit_per_block_exceeded() {
 		//Arrange
 		init_omnipool();
 
-		let lrna_balance_in_omnipool = Tokens::free_balance(LRNA, &Omnipool::protocol_account());
-		let trade_volume_limit = CircuitBreaker::trade_volume_limit_per_asset(LRNA);
-		let sell_amount = CircuitBreaker::calculate_limit(lrna_balance_in_omnipool, trade_volume_limit)
-			.unwrap()
-			.checked_add(1)
-			.unwrap();
-
 		assert_ok!(Tokens::set_balance(
 			RawOrigin::Root.into(),
 			ALICE.into(),
 			LRNA,
-			sell_amount,
+			1000000000000 * UNITS,
 			0,
 		));
 
 		let min_limit = 0;
+		let sell_amount = 300000 * UNITS;
+
+		//We need to split in multiple sells to avoid max in ratio error
+		for _ in 1..=3 {
+			assert_ok!(Omnipool::sell(
+				hydradx_runtime::Origin::signed(ALICE.into()),
+				LRNA,
+				CORE_ASSET_ID,
+				sell_amount,
+				min_limit
+			));
+		}
 
 		//Act and assert
 		assert_noop!(

--- a/integration-tests/src/circuit_breaker.rs
+++ b/integration-tests/src/circuit_breaker.rs
@@ -204,13 +204,21 @@ fn buy_in_omnipool_should_fail_when_max_trade_limit_per_block_exceeded() {
 			0,
 		));
 
+		assert_ok!(Omnipool::buy(
+			hydradx_runtime::Origin::signed(ALICE.into()),
+			CORE_ASSET_ID,
+			DAI,
+			100000 * UNITS,
+			Balance::MAX
+		));
+
 		//Act and assert
 		assert_noop!(
 			Omnipool::buy(
 				hydradx_runtime::Origin::signed(ALICE.into()),
 				CORE_ASSET_ID,
 				DAI,
-				100000 * UNITS,
+				50000 * UNITS,
 				Balance::MAX
 			),
 			pallet_circuit_breaker::Error::<hydradx_runtime::Runtime>::MaxTradeVolumePerBlockReached

--- a/pallets/circuit-breaker/Cargo.toml
+++ b/pallets/circuit-breaker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-circuit-breaker"
-version = "1.0.2"
+version = "1.1.0"
 authors = ["GalacticCouncil <hydradx@galacticcouncil.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/pallets/circuit-breaker/README.md
+++ b/pallets/circuit-breaker/README.md
@@ -1,11 +1,10 @@
 ### Circuit Breaker pallet
 
-By using this pallet, we can limit the percentage of the liquidity of a pool that can be traded (net volume) or added in a block.
+By using this pallet, we can track and limit the percentage of the liquidity of a pool that can be traded (net volume), added and removed in a block.
 
-Two different limits are tracked independently for all assets: trading limit and liquidity added.
-The limits are updated by calling a corresponding handler.
+Three different limits are tracked independently for all assets: trading limit, liquidity added, and liquidity removed.
 
-All trading volumes and amounts of provided liquidity are reset to zero at the end of block execution, so no values are actually stored in the database.
+All trading volumes and amounts of liquidity are reset to zero at the end of block execution, so no values are actually stored in the database.
 
 The default percentage limits are set for all assets in the pallet config.
 To set a specific trade limit for a given asset, the `set_trade_volume_limit` extrinsic can be executed by `TechnicalOrigin`.

--- a/pallets/circuit-breaker/src/lib.rs
+++ b/pallets/circuit-breaker/src/lib.rs
@@ -202,16 +202,19 @@ pub mod pallet {
 
 		/// The maximum percentage of a pool's liquidity that can be traded in a block.
 		/// Represented as a non-zero fraction (nominator, denominator) with the max value being 10_000.
+		#[pallet::constant]
 		type DefaultMaxNetTradeVolumeLimitPerBlock: Get<(u32, u32)>;
 
 		/// The maximum percentage of a pool's liquidity that can be added in a block.
 		/// Represented as an optional non-zero fraction (nominator, denominator) with the max value being 10_000.
 		/// If set to None, the limits are not enforced.
+		#[pallet::constant]
 		type DefaultMaxAddLiquidityLimitPerBlock: Get<Option<(u32, u32)>>;
 
 		/// The maximum percentage of a pool's liquidity that can be removed in a block.
 		/// Represented as an optional non-zero fraction (nominator, denominator) with the max value being 10_000.
 		/// If set to None, the limits are not enforced.
+		#[pallet::constant]
 		type DefaultMaxRemoveLiquidityLimitPerBlock: Get<Option<(u32, u32)>>;
 
 		/// Omnipool's hub asset id. The limits are not tracked for this asset.
@@ -220,6 +223,13 @@ pub mod pallet {
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 	}
+
+	#[pallet::extra_constants]
+		impl<T: Config> Pallet<T> {
+			pub fn default_max_net_trade_volume_limit() -> (u32, u32) {
+				T::DefaultMaxNetTradeVolumeLimitPerBlock::get()
+			}
+		}
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]

--- a/pallets/circuit-breaker/src/lib.rs
+++ b/pallets/circuit-breaker/src/lib.rs
@@ -63,31 +63,31 @@ where
 		Ok(())
 	}
 
-	pub fn check_min_limit(&self) -> DispatchResult {
+	pub fn check_outflow_limit(&self) -> DispatchResult {
 		if self.volume_out > self.volume_in {
 			let diff = self
 				.volume_out
 				.checked_sub(&self.volume_in)
 				.ok_or(ArithmeticError::Underflow)?;
-			ensure!(diff <= self.limit, Error::<T>::MinTradeVolumePerBlockReached);
+			ensure!(diff <= self.limit, Error::<T>::TokenOutflowLimitReached);
 		}
 		Ok(())
 	}
 
-	pub fn check_max_limit(&self) -> DispatchResult {
+	pub fn check_influx_limit(&self) -> DispatchResult {
 		if self.volume_in > self.volume_out {
 			let diff = self
 				.volume_in
 				.checked_sub(&self.volume_out)
 				.ok_or(ArithmeticError::Underflow)?;
-			ensure!(diff <= self.limit, Error::<T>::MaxTradeVolumePerBlockReached);
+			ensure!(diff <= self.limit, Error::<T>::TokenInfluxLimitReached);
 		}
 		Ok(())
 	}
 
 	pub fn check_limits(&self) -> DispatchResult {
-		self.check_min_limit()?;
-		self.check_max_limit()?;
+		self.check_outflow_limit()?;
+		self.check_influx_limit()?;
 		Ok(())
 	}
 }
@@ -312,10 +312,10 @@ pub mod pallet {
 		InvalidLimitValue,
 		/// Allowed liquidity limit is not stored for asset
 		LiquidityLimitNotStoredForAsset,
-		/// Minimum pool's trade volume per block has been reached
-		MinTradeVolumePerBlockReached,
-		/// Maximum pool's trade volume per block has been reached
-		MaxTradeVolumePerBlockReached,
+		/// Token trade outflow per block has been reached
+		TokenOutflowLimitReached,
+		/// Token trade influx per block has been reached
+		TokenInfluxLimitReached,
 		/// Maximum pool's liquidity limit per block has been reached
 		MaxLiquidityLimitPerBlockReached,
 		/// Asset is not allowed to have a limit

--- a/pallets/circuit-breaker/src/lib.rs
+++ b/pallets/circuit-breaker/src/lib.rs
@@ -224,13 +224,6 @@ pub mod pallet {
 		type WeightInfo: WeightInfo;
 	}
 
-	#[pallet::extra_constants]
-		impl<T: Config> Pallet<T> {
-			pub fn default_max_net_trade_volume_limit() -> (u32, u32) {
-				T::DefaultMaxNetTradeVolumeLimitPerBlock::get()
-			}
-		}
-
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
 	pub struct Pallet<T>(_);

--- a/pallets/circuit-breaker/src/tests/omnipool.rs
+++ b/pallets/circuit-breaker/src/tests/omnipool.rs
@@ -131,7 +131,7 @@ fn sell_should_fail_when_trade_volume_max_limit_exceeded() {
 			// Act & Assert
 			assert_noop!(
 				Omnipool::sell(Origin::signed(TRADER), DOT, ACA, sell_amount, min_limit),
-				pallet_circuit_breaker::Error::<Test>::MaxTradeVolumePerBlockReached
+				pallet_circuit_breaker::Error::<Test>::TokenInfluxLimitReached
 			);
 		});
 }
@@ -165,7 +165,7 @@ fn sell_should_fail_when_consequent_trades_exceed_trade_volume_max_limit() {
 
 			assert_noop!(
 				Omnipool::sell(Origin::signed(TRADER), DOT, ACA, sell_amount, min_limit),
-				pallet_circuit_breaker::Error::<Test>::MaxTradeVolumePerBlockReached
+				pallet_circuit_breaker::Error::<Test>::TokenInfluxLimitReached
 			);
 		});
 }
@@ -198,7 +198,7 @@ fn sell_should_fail_when_trade_volume_min_limit_exceeded() {
 			//Asset_out amount would be 1056_910_569_105_689 in a successful trade, but it fails due to limit
 			assert_noop!(
 				Omnipool::sell(Origin::signed(TRADER), DOT, ACA, sell_amount, min_limit),
-				pallet_circuit_breaker::Error::<Test>::MinTradeVolumePerBlockReached
+				pallet_circuit_breaker::Error::<Test>::TokenOutflowLimitReached
 			);
 		});
 }
@@ -232,7 +232,7 @@ fn sell_should_fail_when_consequent_trades_exceed_trade_volume_min_limit() {
 
 			assert_noop!(
 				Omnipool::sell(Origin::signed(TRADER), DOT, ACA, sell_amount, min_limit),
-				pallet_circuit_breaker::Error::<Test>::MinTradeVolumePerBlockReached
+				pallet_circuit_breaker::Error::<Test>::TokenOutflowLimitReached
 			);
 		});
 }
@@ -346,7 +346,7 @@ fn buy_should_fail_when_trade_volume_max_limit_exceeded() {
 			//Asset_in amount would be 1250_000_000_000_002 in a successful trade, but it fails due to limit
 			assert_noop!(
 				Omnipool::buy(Origin::signed(TRADER), DOT, ACA, buy_amount, Balance::MAX),
-				pallet_circuit_breaker::Error::<Test>::MaxTradeVolumePerBlockReached
+				pallet_circuit_breaker::Error::<Test>::TokenInfluxLimitReached
 			);
 		});
 }
@@ -386,7 +386,7 @@ fn buy_should_fail_when_consequent_trades_exceed_trade_volume_max_limit() {
 
 			assert_noop!(
 				Omnipool::buy(Origin::signed(TRADER), DOT, ACA, buy_amount, Balance::MAX),
-				pallet_circuit_breaker::Error::<Test>::MaxTradeVolumePerBlockReached
+				pallet_circuit_breaker::Error::<Test>::TokenInfluxLimitReached
 			);
 		});
 }
@@ -418,7 +418,7 @@ fn buy_should_fail_when_trade_volume_min_limit_exceeded() {
 			// Act & assert
 			assert_noop!(
 				Omnipool::buy(Origin::signed(TRADER), DOT, ACA, buy_amount, Balance::MAX),
-				pallet_circuit_breaker::Error::<Test>::MinTradeVolumePerBlockReached
+				pallet_circuit_breaker::Error::<Test>::TokenOutflowLimitReached
 			);
 		});
 }
@@ -458,7 +458,7 @@ fn buy_should_fail_when_consequent_trades_exceed_trade_volume_min_limit() {
 
 			assert_noop!(
 				Omnipool::buy(Origin::signed(TRADER), DOT, ACA, buy_amount, Balance::MAX),
-				pallet_circuit_breaker::Error::<Test>::MinTradeVolumePerBlockReached
+				pallet_circuit_breaker::Error::<Test>::TokenOutflowLimitReached
 			);
 		});
 }

--- a/pallets/circuit-breaker/src/tests/trade_volume.rs
+++ b/pallets/circuit-breaker/src/tests/trade_volume.rs
@@ -162,7 +162,7 @@ fn ensure_and_update_trade_volume_limit_should_fail_when_min_limit_is_reached() 
 		// Act & Assert
 		assert_noop!(
 			CircuitBreaker::ensure_and_update_trade_volume_limit(DOT, 0, HDX, 200_001),
-			Error::<Test>::MinTradeVolumePerBlockReached
+			Error::<Test>::TokenOutflowLimitReached
 		);
 	});
 }
@@ -185,7 +185,7 @@ fn ensure_and_update_trade_volume_limit_should_fail_when_max_limit_is_reached() 
 		// Act & Assert
 		assert_noop!(
 			CircuitBreaker::ensure_and_update_trade_volume_limit(HDX, 200_001, DOT, 0),
-			Error::<Test>::MaxTradeVolumePerBlockReached
+			Error::<Test>::TokenInfluxLimitReached
 		);
 	});
 }
@@ -233,7 +233,7 @@ fn ensure_and_update_trade_volume_limit_should_fail_when_max_limit_is_reached_fr
 		// Act & Assert
 		assert_noop!(
 			CircuitBreaker::ensure_and_update_trade_volume_limit(HDX, 150_000, DOT, 0),
-			Error::<Test>::MaxTradeVolumePerBlockReached
+			Error::<Test>::TokenInfluxLimitReached
 		);
 	});
 }

--- a/pallets/omnipool/Cargo.toml
+++ b/pallets/omnipool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-omnipool"
-version = "1.6.6"
+version = "1.6.7"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"

--- a/pallets/omnipool/src/lib.rs
+++ b/pallets/omnipool/src/lib.rs
@@ -503,7 +503,7 @@ pub mod pallet {
 		///
 		/// Emits `TokenAdded` event when successful.
 		///
-		#[pallet::weight(<T as Config>::WeightInfo::add_token())]
+		#[pallet::weight(<T as Config>::WeightInfo::add_token().saturating_add(T::OmnipoolHooks::on_liquidity_changed_weight()))]
 		#[transactional]
 		pub fn add_token(
 			origin: OriginFor<T>,

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common-runtime"
-version = "102.0.0"
+version = "102.1.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/common/src/weights/circuit_breaker.rs
+++ b/runtime/common/src/weights/circuit_breaker.rs
@@ -55,8 +55,6 @@ impl<T: frame_system::Config> WeightInfo for HydraWeight<T> {
 		Weight::from_ref_time(0 as u64) // Standard Error: 7_000
 			.saturating_add(Weight::from_ref_time(927_000 as u64).saturating_mul(n as u64)) // Standard Error: 7_000
 			.saturating_add(Weight::from_ref_time(1_753_000 as u64).saturating_mul(m as u64))
-			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(n as u64)))
-			.saturating_add(T::DbWeight::get().writes((2 as u64).saturating_mul(m as u64)))
 	}
 	fn on_finalize_single() -> Weight {
 		Weight::from_ref_time(8_470_000 as u64)


### PR DESCRIPTION
- [x] make default limits accessible as constants in metadata
- [x] fix integration tests
- [x] adjust weights returned from Omnipool extrinsics
- [x] update readme
- [x] consider renaming the min limit as it is confusing
- [ ] rebenchmark `on_finalize` method