### PR TITLE
chore: remove unused omnipool api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6322,7 +6322,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-omnipool"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "bitflags",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6322,7 +6322,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-omnipool"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "bitflags",
  "frame-benchmarking",

--- a/pallets/omnipool/Cargo.toml
+++ b/pallets/omnipool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-omnipool"
-version = "2.0.3"
+version = "2.0.4"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"

--- a/pallets/omnipool/Cargo.toml
+++ b/pallets/omnipool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-omnipool"
-version = "2.0.4"
+version = "2.0.5"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
This PR removes unused omnipool public functions. These removed functions would be only needed for subpool integration, however as discussed, trade will be routed through omnipool and stableswap directly. There is no need for them