### PR TITLE
fix: reroute XCM tokens going to Omnipool Account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,7 +1080,6 @@ dependencies = [
  "sp-std",
  "substrate-wasm-builder",
  "xcm",
- "xcm-builder",
  "xcm-executor",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,6 +1046,7 @@ dependencies = [
  "orml-tokens",
  "orml-traits",
  "orml-vesting",
+ "orml-xcm-support",
  "pallet-asset-registry",
  "pallet-balances",
  "pallet-circuit-breaker",
@@ -1078,6 +1079,9 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "substrate-wasm-builder",
+ "xcm",
+ "xcm-builder",
+ "xcm-executor",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "102.3.6"
+version = "102.3.7"
 dependencies = [
  "cumulus-pallet-xcmp-queue",
  "frame-support",
@@ -3417,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "150.0.0"
+version = "151.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",
@@ -8984,7 +8984,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",
@@ -11743,7 +11743,7 @@ dependencies = [
 
 [[package]]
 name = "testing-hydradx-runtime"
-version = "150.0.0"
+version = "151.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.7.4"
+version = "1.7.5"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/cross_chain_transfer.rs
+++ b/integration-tests/src/cross_chain_transfer.rs
@@ -229,11 +229,19 @@ fn hydra_treasury_should_receive_asset_when_transferred_to_protocol_account() {
 	TestNet::reset();
 
 	Hydra::execute_with(|| {
+		// initialize the omnipool because we check whether assets are present there
+		init_omnipool();
+
 		assert_ok!(hydradx_runtime::AssetRegistry::set_location(
 			hydradx_runtime::Origin::root(),
-			1,
+			DAI, // we pretend that the incoming tokens are DAI
 			hydradx_runtime::AssetLocation(MultiLocation::new(1, X2(Parachain(ACALA_PARA_ID), GeneralIndex(0))))
 		));
+
+		assert_eq!(
+			hydradx_runtime::Tokens::free_balance(DAI, &hydradx_runtime::Omnipool::protocol_account()),
+			50_000_000_000 * UNITS
+		);
 	});
 
 	Acala::execute_with(|| {
@@ -267,11 +275,11 @@ fn hydra_treasury_should_receive_asset_when_transferred_to_protocol_account() {
 
 	Hydra::execute_with(|| {
 		assert_eq!(
-			hydradx_runtime::Tokens::free_balance(1, &AccountId::from(BOB)),
-			1_000 * UNITS
+			hydradx_runtime::Tokens::free_balance(DAI, &hydradx_runtime::Omnipool::protocol_account()),
+			50_000_000_000 * UNITS
 		);
 		assert_eq!(
-			hydradx_runtime::Tokens::free_balance(1, &hydradx_runtime::Treasury::account_id()),
+			hydradx_runtime::Tokens::free_balance(DAI, &hydradx_runtime::Treasury::account_id()),
 			30 * UNITS // fee and tokens should go to treasury
 		);
 	});

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common-runtime"
-version = "102.3.6"
+version = "102.3.7"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -57,10 +57,16 @@ pallet-ema-oracle =  { git = "https://github.com/galacticcouncil/warehouse", rev
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }
 orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }
 
 # Cumulus dependencies
 pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29", default-features = false }
 cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29", default-features = false }
+
+# Polkadot dependencies
+xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29-1", default-features = false }
+xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29-1", default-features = false }
+xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29-1", default-features = false }
 
 [features]
 default = ["std"]
@@ -96,6 +102,10 @@ std = [
     "orml-tokens/std",
     "orml-vesting/std",
     "orml-traits/std",
+    "orml-xcm-support/std",
     "pallet-collator-selection/std",
     "cumulus-pallet-xcmp-queue/std",
+    "xcm/std",
+    "xcm-builder/std",
+    "xcm-executor/std",
 ]

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -65,7 +65,6 @@ cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus", bra
 
 # Polkadot dependencies
 xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29-1", default-features = false }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29-1", default-features = false }
 xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29-1", default-features = false }
 
 [features]
@@ -106,6 +105,5 @@ std = [
     "pallet-collator-selection/std",
     "cumulus-pallet-xcmp-queue/std",
     "xcm/std",
-    "xcm-builder/std",
     "xcm-executor/std",
 ]

--- a/runtime/common/src/adapters.rs
+++ b/runtime/common/src/adapters.rs
@@ -1,6 +1,10 @@
 use core::marker::PhantomData;
 
-use frame_support::{traits::Get, weights::Weight};
+use codec::FullCodec;
+use frame_support::{
+	traits::{Contains, Get},
+	weights::Weight,
+};
 use hydra_dx_math::ema::EmaPrice;
 use hydra_dx_math::omnipool::types::BalanceUpdate;
 use hydra_dx_math::support::rational::round_to_rational;
@@ -8,15 +12,26 @@ use hydra_dx_math::support::rational::Rounding;
 use hydradx_traits::AggregatedPriceOracle;
 use hydradx_traits::PriceOracle;
 use hydradx_traits::{liquidity_mining::PriceAdjustment, OnLiquidityChangedHandler, OnTradeHandler, OraclePeriod};
+use orml_xcm_support::OnDepositFail;
+use orml_xcm_support::UnknownAsset as UnknownAssetT;
 use pallet_circuit_breaker::WeightInfo;
 use pallet_ema_oracle::Price;
 use pallet_ema_oracle::{OnActivityHandler, OracleError};
 use pallet_omnipool::traits::{AssetInfo, ExternalPriceProvider, OmnipoolHooks};
 use primitive_types::U128;
 use primitives::{AssetId, Balance, BlockNumber};
-use sp_runtime::traits::Zero;
+use sp_runtime::traits::MaybeSerializeDeserialize;
+use sp_runtime::traits::{Convert, Zero};
+use sp_runtime::SaturatedConversion;
 use sp_runtime::{ArithmeticError, DispatchError, FixedPointNumber, FixedU128};
+use sp_std::fmt::Debug;
 use warehouse_liquidity_mining::GlobalFarmData;
+use xcm::latest::prelude::*;
+use xcm_executor::{
+	traits::{Convert as MoreConvert, MatchesFungible, TransactAsset},
+	Assets,
+};
+
 /// Passes on trade and liquidity data from the omnipool to the oracle.
 pub struct OmnipoolHookAdapter<Origin, Lrna, Runtime>(PhantomData<(Origin, Lrna, Runtime)>);
 
@@ -230,5 +245,146 @@ where
 		.map_err(|_| pallet_omnipool_liquidity_mining::Error::<Runtime>::PriceAdjustmentNotAvailable)?;
 
 		FixedU128::checked_from_rational(price.n, price.d).ok_or(ArithmeticError::Overflow.into())
+	}
+}
+
+/// Asset transaction errors.
+enum Error {
+	/// Failed to match fungible.
+	FailedToMatchFungible,
+	/// `MultiLocation` to `AccountId` Conversion failed.
+	AccountIdConversionFailed,
+	/// `CurrencyId` conversion failed.
+	CurrencyIdConversionFailed,
+}
+
+impl From<Error> for XcmError {
+	fn from(e: Error) -> Self {
+		match e {
+			Error::FailedToMatchFungible => XcmError::FailedToTransactAsset("FailedToMatchFungible"),
+			Error::AccountIdConversionFailed => XcmError::FailedToTransactAsset("AccountIdConversionFailed"),
+			Error::CurrencyIdConversionFailed => XcmError::FailedToTransactAsset("CurrencyIdConversionFailed"),
+		}
+	}
+}
+
+/// The `TransactAsset` implementation, to handle `MultiAsset` deposit/withdraw, but reroutes deposits and transfers
+/// to unsupported accounts to an alternative
+/// .
+/// Note that teleport related functions are unimplemented.
+///
+/// Methods of `DepositFailureHandler` would be called on multi-currency deposit
+/// errors.
+///
+/// If the asset is known, deposit/withdraw will be handled by `MultiCurrency`,
+/// else by `UnknownAsset` if unknown.
+#[allow(clippy::type_complexity)]
+pub struct ReroutingMultiCurrencyAdapter<
+	MultiCurrency,
+	UnknownAsset,
+	Match,
+	AccountId,
+	AccountIdConvert,
+	CurrencyId,
+	CurrencyIdConvert,
+	DepositFailureHandler,
+	RerouteFilter,
+	AlternativeDestination,
+>(
+	PhantomData<(
+		MultiCurrency,
+		UnknownAsset,
+		Match,
+		AccountId,
+		AccountIdConvert,
+		CurrencyId,
+		CurrencyIdConvert,
+		DepositFailureHandler,
+		RerouteFilter,
+		AlternativeDestination,
+	)>,
+);
+
+impl<
+		MultiCurrency: orml_traits::MultiCurrency<AccountId, CurrencyId = CurrencyId>,
+		UnknownAsset: UnknownAssetT,
+		Match: MatchesFungible<MultiCurrency::Balance>,
+		AccountId: sp_std::fmt::Debug + Clone,
+		AccountIdConvert: MoreConvert<MultiLocation, AccountId>,
+		CurrencyId: FullCodec + Eq + PartialEq + Copy + MaybeSerializeDeserialize + Debug,
+		CurrencyIdConvert: Convert<MultiAsset, Option<CurrencyId>>,
+		DepositFailureHandler: OnDepositFail<CurrencyId, AccountId, MultiCurrency::Balance>,
+		RerouteFilter: Contains<AccountId>,
+		AlternativeDestination: Get<AccountId>,
+	> TransactAsset
+	for ReroutingMultiCurrencyAdapter<
+		MultiCurrency,
+		UnknownAsset,
+		Match,
+		AccountId,
+		AccountIdConvert,
+		CurrencyId,
+		CurrencyIdConvert,
+		DepositFailureHandler,
+		RerouteFilter,
+		AlternativeDestination,
+	>
+{
+	fn deposit_asset(asset: &MultiAsset, location: &MultiLocation) -> Result<(), XcmError> {
+		match (
+			AccountIdConvert::convert_ref(location),
+			CurrencyIdConvert::convert(asset.clone()),
+			Match::matches_fungible(asset),
+		) {
+			// known asset
+			(Ok(who), Some(currency_id), Some(amount)) => {
+				if RerouteFilter::contains(&who) {
+					MultiCurrency::deposit(currency_id, &AlternativeDestination::get(), amount)
+						.or_else(|err| DepositFailureHandler::on_deposit_currency_fail(err, currency_id, &who, amount))
+				} else {
+					MultiCurrency::deposit(currency_id, &who, amount)
+						.or_else(|err| DepositFailureHandler::on_deposit_currency_fail(err, currency_id, &who, amount))
+				}
+			}
+			// unknown asset
+			_ => UnknownAsset::deposit(asset, location)
+				.or_else(|err| DepositFailureHandler::on_deposit_unknown_asset_fail(err, asset, location)),
+		}
+	}
+
+	fn withdraw_asset(asset: &MultiAsset, location: &MultiLocation) -> Result<Assets, XcmError> {
+		UnknownAsset::withdraw(asset, location).or_else(|_| {
+			let who = AccountIdConvert::convert_ref(location)
+				.map_err(|_| XcmError::from(Error::AccountIdConversionFailed))?;
+			let currency_id = CurrencyIdConvert::convert(asset.clone())
+				.ok_or_else(|| XcmError::from(Error::CurrencyIdConversionFailed))?;
+			let amount: MultiCurrency::Balance = Match::matches_fungible(asset)
+				.ok_or_else(|| XcmError::from(Error::FailedToMatchFungible))?
+				.saturated_into();
+			MultiCurrency::withdraw(currency_id, &who, amount).map_err(|e| XcmError::FailedToTransactAsset(e.into()))
+		})?;
+
+		Ok(asset.clone().into())
+	}
+
+	fn transfer_asset(asset: &MultiAsset, from: &MultiLocation, to: &MultiLocation) -> Result<Assets, XcmError> {
+		let from_account =
+			AccountIdConvert::convert_ref(from).map_err(|_| XcmError::from(Error::AccountIdConversionFailed))?;
+		let to_account =
+			AccountIdConvert::convert_ref(to).map_err(|_| XcmError::from(Error::AccountIdConversionFailed))?;
+		let to_account = if RerouteFilter::contains(&to_account) {
+			AlternativeDestination::get()
+		} else {
+			to_account
+		};
+		let currency_id = CurrencyIdConvert::convert(asset.clone())
+			.ok_or_else(|| XcmError::from(Error::CurrencyIdConversionFailed))?;
+		let amount: MultiCurrency::Balance = Match::matches_fungible(asset)
+			.ok_or_else(|| XcmError::from(Error::FailedToMatchFungible))?
+			.saturated_into();
+		MultiCurrency::transfer(currency_id, &from_account, &to_account, amount)
+			.map_err(|e| XcmError::FailedToTransactAsset(e.into()))?;
+
+		Ok(asset.clone().into())
 	}
 }

--- a/runtime/common/src/adapters.rs
+++ b/runtime/common/src/adapters.rs
@@ -269,8 +269,8 @@ impl From<Error> for XcmError {
 }
 
 /// The `TransactAsset` implementation, to handle `MultiAsset` deposit/withdraw, but reroutes deposits and transfers
-/// to unsupported accounts to an alternative
-/// .
+/// to unsupported accounts to an alternative.
+///
 /// Note that teleport related functions are unimplemented.
 ///
 /// Methods of `DepositFailureHandler` would be called on multi-currency deposit

--- a/runtime/common/src/adapters.rs
+++ b/runtime/common/src/adapters.rs
@@ -278,6 +278,9 @@ impl From<Error> for XcmError {
 ///
 /// If the asset is known, deposit/withdraw will be handled by `MultiCurrency`,
 /// else by `UnknownAsset` if unknown.
+///
+/// Taken and modified from `orml_xcm_support`.
+/// https://github.com/open-web3-stack/open-runtime-module-library/blob/4ae0372e2c624e6acc98305564b9d395f70814c0/xcm-support/src/currency_adapter.rs#L96-L202
 #[allow(clippy::type_complexity)]
 pub struct ReroutingMultiCurrencyAdapter<
 	MultiCurrency,

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "150.0.0"
+version = "151.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -100,7 +100,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 150,
+	spec_version: 151,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/hydradx/src/xcm.rs
+++ b/runtime/hydradx/src/xcm.rs
@@ -1,5 +1,6 @@
 use super::{AssetId, *};
 
+use common_runtime::adapters::ReroutingMultiCurrencyAdapter;
 use cumulus_primitives_core::ParaId;
 use frame_support::{
 	traits::{Everything, Nothing},
@@ -268,9 +269,17 @@ pub type LocationToAccountId = (
 parameter_types! {
 	// The account which receives multi-currency tokens from failed attempts to deposit them
 	pub Alternative: AccountId = PalletId(*b"xcm/alte").into_account_truncating();
+	pub AlternativeDestination: AccountId = Treasury::account_id();
 }
 
-pub type LocalAssetTransactor = MultiCurrencyAdapter<
+pub struct OmnipoolProtocolAccount;
+impl Contains<AccountId> for OmnipoolProtocolAccount {
+	fn contains(account_id: &AccountId) -> bool {
+		&Omnipool::protocol_account() == account_id
+	}
+}
+
+pub type LocalAssetTransactor = ReroutingMultiCurrencyAdapter<
 	Currencies,
 	UnknownTokens,
 	IsNativeConcrete<AssetId, CurrencyIdConvert>,
@@ -279,4 +288,6 @@ pub type LocalAssetTransactor = MultiCurrencyAdapter<
 	AssetId,
 	CurrencyIdConvert,
 	DepositToAlternative<Alternative, Currencies, AssetId, AccountId, Balance>,
+	OmnipoolProtocolAccount,
+	AlternativeDestination,
 >;

--- a/runtime/hydradx/src/xcm.rs
+++ b/runtime/hydradx/src/xcm.rs
@@ -269,13 +269,13 @@ pub type LocationToAccountId = (
 parameter_types! {
 	// The account which receives multi-currency tokens from failed attempts to deposit them
 	pub Alternative: AccountId = PalletId(*b"xcm/alte").into_account_truncating();
-	pub AlternativeDestination: AccountId = Treasury::account_id();
+	pub RerouteDestination: AccountId = Treasury::account_id();
 }
 
 pub struct OmnipoolProtocolAccount;
-impl Contains<AccountId> for OmnipoolProtocolAccount {
-	fn contains(account_id: &AccountId) -> bool {
-		&Omnipool::protocol_account() == account_id
+impl Contains<(AssetId, AccountId)> for OmnipoolProtocolAccount {
+	fn contains((c, account_id): &(AssetId, AccountId)) -> bool {
+		&Omnipool::protocol_account() == account_id && Omnipool::exists(*c)
 	}
 }
 
@@ -289,5 +289,5 @@ pub type LocalAssetTransactor = ReroutingMultiCurrencyAdapter<
 	CurrencyIdConvert,
 	DepositToAlternative<Alternative, Currencies, AssetId, AccountId, Balance>,
 	OmnipoolProtocolAccount,
-	AlternativeDestination,
+	RerouteDestination,
 >;

--- a/runtime/hydradx/src/xcm.rs
+++ b/runtime/hydradx/src/xcm.rs
@@ -269,7 +269,6 @@ pub type LocationToAccountId = (
 parameter_types! {
 	// The account which receives multi-currency tokens from failed attempts to deposit them
 	pub Alternative: AccountId = PalletId(*b"xcm/alte").into_account_truncating();
-	pub RerouteDestination: AccountId = Treasury::account_id();
 }
 
 pub struct OmnipoolProtocolAccount;
@@ -279,6 +278,7 @@ impl Contains<(AssetId, AccountId)> for OmnipoolProtocolAccount {
 	}
 }
 
+/// We use `orml::Currencies` for asset transacting. Transfers to active Omnipool accounts are rerouted to the treasury.
 pub type LocalAssetTransactor = ReroutingMultiCurrencyAdapter<
 	Currencies,
 	UnknownTokens,
@@ -289,5 +289,5 @@ pub type LocalAssetTransactor = ReroutingMultiCurrencyAdapter<
 	CurrencyIdConvert,
 	DepositToAlternative<Alternative, Currencies, AssetId, AccountId, Balance>,
 	OmnipoolProtocolAccount,
-	RerouteDestination,
+	TreasuryAccount,
 >;

--- a/runtime/testing-hydradx/Cargo.toml
+++ b/runtime/testing-hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testing-hydradx-runtime"
-version = "150.0.0"
+version = "151.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/testing-hydradx/src/lib.rs
+++ b/runtime/testing-hydradx/src/lib.rs
@@ -111,7 +111,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("testing-hydradx"),
 	impl_name: create_runtime_str!("testing-hydradx"),
 	authoring_version: 1,
-	spec_version: 150,
+	spec_version: 151,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- We are using semantinc pull request to make our lives easier -->
<!--- Please use prefixes for the title and use ! before : if breaking like below -->
<!--- build: ci: docs: feat: perf: refactor: fix: style: test: refactor!: -->
When receiving tokens via `TransactAsset` we check whether it is trying to go into an existing Omnipool account. If that's the case we reroute into the treasury.
Replaces the existing ORML `TransactAsset` implementation with a near-clone.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to disallow price manipulation via moving tokens into pool accounts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See the included integration test.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation if necessary.
- [x] I have added tests to cover my changes, regression test if fixing an issue.
- [x] This is a breaking change.
