### PR TITLE
feat: asset registry xcm rate limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3632,8 +3632,8 @@ dependencies = [
 
 [[package]]
 name = "hydra-dx-math"
-version = "7.0.1"
-source = "git+https://github.com/galacticcouncil/HydraDX-math?rev=35e5c0775a07e057ed5247ba96dfa254d691f034#35e5c0775a07e057ed5247ba96dfa254d691f034"
+version = "7.1.0"
+source = "git+https://github.com/galacticcouncil/HydraDX-math?rev=380b80b59bbf62abb8848fb8a10bb206861eab41#380b80b59bbf62abb8848fb8a10bb206861eab41"
 dependencies = [
  "fixed",
  "num-traits",
@@ -3729,7 +3729,7 @@ dependencies = [
 [[package]]
 name = "hydradx-adapters"
 version = "0.3.0"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-support",
  "hydradx-traits",
@@ -3842,7 +3842,7 @@ dependencies = [
 [[package]]
 name = "hydradx-traits"
 version = "2.3.0"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -6104,8 +6104,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-registry"
-version = "2.1.1"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+version = "2.2.0"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6358,7 +6358,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-rewards"
 version = "1.0.4"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6430,7 +6430,7 @@ dependencies = [
 [[package]]
 name = "pallet-currencies"
 version = "1.2.1"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6465,7 +6465,7 @@ dependencies = [
 [[package]]
 name = "pallet-duster"
 version = "3.2.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6536,7 +6536,7 @@ dependencies = [
 [[package]]
 name = "pallet-ema-oracle"
 version = "1.0.3"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6665,8 +6665,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-liquidity-mining"
-version = "4.2.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+version = "4.2.3"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6893,7 +6893,7 @@ dependencies = [
 [[package]]
 name = "pallet-otc"
 version = "1.0.1"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6994,7 +6994,7 @@ dependencies = [
 [[package]]
 name = "pallet-relaychain-info"
 version = "0.3.3"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -7188,7 +7188,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-multi-payment"
 version = "9.0.1"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7206,7 +7206,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-pause"
 version = "0.1.3"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12633,7 +12633,7 @@ dependencies = [
 [[package]]
 name = "test-utils"
 version = "1.1.1"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-system",
  "pretty_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "102.3.8"
+version = "102.3.9"
 dependencies = [
  "cumulus-pallet-xcmp-queue",
  "frame-support",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "152.0.0"
+version = "153.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",
@@ -6307,7 +6307,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-circuit-breaker"
-version = "1.1.9"
+version = "1.1.10"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6836,7 +6836,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-omnipool"
-version = "2.0.8"
+version = "2.0.9"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
@@ -6863,7 +6863,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-omnipool-liquidity-mining"
-version = "2.0.7"
+version = "2.0.8"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
@@ -9749,7 +9749,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.7.6"
+version = "1.7.7"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",
@@ -12641,7 +12641,7 @@ dependencies = [
 
 [[package]]
 name = "testing-hydradx-runtime"
-version = "152.0.0"
+version = "153.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -20,15 +20,15 @@ pallet-circuit-breaker = { path = "../pallets/circuit-breaker",default-features 
 pallet-omnipool-liquidity-mining = { path = "../pallets/omnipool-liquidity-mining", default-features = true}
 
 # Warehouse dependencies
-pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse",rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-duster = { git = "https://github.com/galacticcouncil/warehouse",rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-ema-oracle = { git = "https://github.com/galacticcouncil/warehouse",rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-otc = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd" }
+pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse",rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-duster = { git = "https://github.com/galacticcouncil/warehouse",rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-ema-oracle = { git = "https://github.com/galacticcouncil/warehouse",rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-otc = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334" }
 
 pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }
 pallet-democracy = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }
@@ -111,7 +111,7 @@ polkadot-runtime = { git = "https://github.com/paritytech/polkadot", branch = "r
 [dev-dependencies]
 hex-literal = "0.4.1"
 pretty_assertions = "1.2.1"
-pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd" }
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334" }
 xcm-emulator = { git = "https://github.com/shaunxw/xcm-simulator", rev = "754f3b90ecc65af735a6c9a2e1792c5253926ff6" }
 
 [features]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.7.6"
+version = "1.7.7"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/circuit-breaker/Cargo.toml
+++ b/pallets/circuit-breaker/Cargo.toml
@@ -27,15 +27,15 @@ sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-
 
 
 # Warehouse
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
 
 [dev-dependencies]
 pallet-omnipool = { path = "../omnipool", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.38" }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.38" }
-hydra-dx-math = { git = "https://github.com/galacticcouncil/HydraDX-math", rev = "35e5c0775a07e057ed5247ba96dfa254d691f034", default-features = false }
-test-utils = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
+hydra-dx-math = { git = "https://github.com/galacticcouncil/HydraDX-math", rev = "380b80b59bbf62abb8848fb8a10bb206861eab41", default-features = false }
+test-utils = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
 pretty_assertions = "1.2.1"
 test-case = "3.0.0"
 

--- a/pallets/circuit-breaker/Cargo.toml
+++ b/pallets/circuit-breaker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-circuit-breaker"
-version = "1.1.9"
+version = "1.1.10"
 authors = ["GalacticCouncil <hydradx@galacticcouncil.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/pallets/omnipool-liquidity-mining/Cargo.toml
+++ b/pallets/omnipool-liquidity-mining/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-omnipool-liquidity-mining"
-version = "2.0.7"
+version = "2.0.8"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"

--- a/pallets/omnipool-liquidity-mining/Cargo.toml
+++ b/pallets/omnipool-liquidity-mining/Cargo.toml
@@ -32,11 +32,11 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "polk
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.38", default-features = false }
 
 # Warehouse
-pallet-liquidity-mining = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-ema-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
+pallet-liquidity-mining = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-ema-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
 
-hydra-dx-math = { git = "https://github.com/galacticcouncil/HydraDX-math", rev = "35e5c0775a07e057ed5247ba96dfa254d691f034", default-features = false }
+hydra-dx-math = { git = "https://github.com/galacticcouncil/HydraDX-math", rev = "380b80b59bbf62abb8848fb8a10bb206861eab41", default-features = false }
 
 # third party
 primitive-types = { version = "0.12.0", default-features = false }
@@ -54,7 +54,7 @@ sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.38", default-features = false }
 proptest = "1.0.0"
 pretty_assertions = "1.2.1"
-test-utils = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
+test-utils = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
 
 [features]
 default = ["std"]

--- a/pallets/omnipool/Cargo.toml
+++ b/pallets/omnipool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-omnipool"
-version = "2.0.8"
+version = "2.0.9"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"

--- a/pallets/omnipool/Cargo.toml
+++ b/pallets/omnipool/Cargo.toml
@@ -29,9 +29,9 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "polk
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.38", default-features = false }
 
 # Warehouse
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
 
-hydra-dx-math = { git = "https://github.com/galacticcouncil/HydraDX-math", rev = "35e5c0775a07e057ed5247ba96dfa254d691f034", default-features = false }
+hydra-dx-math = { git = "https://github.com/galacticcouncil/HydraDX-math", rev = "380b80b59bbf62abb8848fb8a10bb206861eab41", default-features = false }
 
 # third party
 primitive-types = { version = "0.12.0", default-features = false }

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common-runtime"
-version = "102.3.8"
+version = "102.3.9"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -23,17 +23,17 @@ pallet-circuit-breaker = {path = '../../pallets/circuit-breaker', default-featur
 pallet-omnipool-liquidity-mining = {path = '../../pallets/omnipool-liquidity-mining', default-features = false}
 pallet-claims = { path = '../../pallets/claims', default-features = false }
 
-hydra-dx-math = { git = "https://github.com/galacticcouncil/HydraDX-math", rev = "35e5c0775a07e057ed5247ba96dfa254d691f034", default-features = false }
+hydra-dx-math = { git = "https://github.com/galacticcouncil/HydraDX-math", rev = "380b80b59bbf62abb8848fb8a10bb206861eab41", default-features = false }
 
 # Warehouse dependencies
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse",rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-otc = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-ema-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse",rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-otc = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-ema-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
 
 # Substrate dependencies
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "152.0.0"
+version = "153.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -50,18 +50,18 @@ pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate", b
 pallet-uniques = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }
 
 # Warehouse dependencies
-hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-collator-rewards = { git = "https://github.com/galacticcouncil/warehouse",rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse",rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-ema-oracle = { git = "https://github.com/galacticcouncil/warehouse",rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-duster = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-otc = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
+hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-collator-rewards = { git = "https://github.com/galacticcouncil/warehouse",rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse",rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-ema-oracle = { git = "https://github.com/galacticcouncil/warehouse",rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-duster = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-otc = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
 
 # ORML dependencies
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.38", default-features = false }

--- a/runtime/hydradx/src/benchmarking/mod.rs
+++ b/runtime/hydradx/src/benchmarking/mod.rs
@@ -21,6 +21,7 @@ pub fn register_asset(name: Vec<u8>, deposit: Balance) -> Result<AssetId, ()> {
 		pallet_asset_registry::AssetType::<AssetId>::Token,
 		deposit,
 		None,
+		None,
 	)
 	.map_err(|_| ())
 }
@@ -33,6 +34,7 @@ pub fn update_asset(asset_id: AssetId, name: Vec<u8>, deposit: Balance) -> Resul
 		name,
 		pallet_asset_registry::AssetType::<AssetId>::Token,
 		Some(deposit),
+		None,
 	)
 	.map_err(|_| ())
 }

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -1108,6 +1108,7 @@ pub type Executive = frame_executive::Executive<
 		ParachainSystem,
 		migrations::OnRuntimeUpgradeMigration,
 		migrations::MigrateRegistryLocationToV3<Runtime>,
+		migrations::XcmRateLimitMigration,
 	),
 >;
 

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -105,7 +105,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 152,
+	spec_version: 153,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/hydradx/src/migrations.rs
+++ b/runtime/hydradx/src/migrations.rs
@@ -82,3 +82,32 @@ where
 		weight
 	}
 }
+
+pub struct XcmRateLimitMigration;
+impl OnRuntimeUpgrade for XcmRateLimitMigration {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+		frame_support::log::info!("PreMigrate Asset Registry Pallet start");
+		pallet_asset_registry::migration::v1::pre_migrate::<Runtime>();
+		frame_support::log::info!("PreMigrate Asset Registry Pallet end");
+
+		Ok(vec![])
+	}
+
+	fn on_runtime_upgrade() -> Weight {
+		log::info!(
+			target: "runtime::asset-registry",
+			"XcmRateLimitMigration::on_runtime_upgrade: migrating asset details to include xcm rate limit"
+		);
+
+		pallet_asset_registry::migration::v1::migrate::<Runtime>()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(_state: Vec<u8>) -> Result<(), &'static str> {
+		frame_support::log::info!("PostMigrate Asset Registry Pallet start");
+		pallet_asset_registry::migration::v1::post_migrate::<Runtime>();
+		frame_support::log::info!("PostMigrate Asset Registry Pallet end");
+		Ok(())
+	}
+}

--- a/runtime/testing-hydradx/Cargo.toml
+++ b/runtime/testing-hydradx/Cargo.toml
@@ -51,18 +51,18 @@ pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate", b
 pallet-uniques = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }
 
 # Warehouse dependencies
-hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-collator-rewards = { git = "https://github.com/galacticcouncil/warehouse",rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse",rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-ema-oracle = { git = "https://github.com/galacticcouncil/warehouse",rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-duster = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-otc = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
+hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-collator-rewards = { git = "https://github.com/galacticcouncil/warehouse",rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse",rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-ema-oracle = { git = "https://github.com/galacticcouncil/warehouse",rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-duster = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-otc = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
 
 # ORML dependencies
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.38", default-features = false }

--- a/runtime/testing-hydradx/Cargo.toml
+++ b/runtime/testing-hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testing-hydradx-runtime"
-version = "152.0.0"
+version = "153.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/testing-hydradx/src/lib.rs
+++ b/runtime/testing-hydradx/src/lib.rs
@@ -113,7 +113,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("testing-hydradx"),
 	impl_name: create_runtime_str!("testing-hydradx"),
 	authoring_version: 1,
-	spec_version: 152,
+	spec_version: 153,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION

Add a migration for the asset registry that removes `locked` and introduces `xcm_rate_limit`.

https://github.com/galacticcouncil/warehouse/pull/209

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation if necessary.
- [ ] I have added tests to cover my changes, regression test if fixing an issue.
- [ ] This is a breaking change.
