### PR TITLE
feat: dca slippages and retries configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,7 +3837,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "157.0.0"
+version = "158.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",
@@ -6574,7 +6574,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-dca"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -10129,7 +10129,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.7.10"
+version = "1.7.11"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",
@@ -13044,7 +13044,7 @@ dependencies = [
 
 [[package]]
 name = "testing-hydradx-runtime"
-version = "157.0.0"
+version = "158.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.7.10"
+version = "1.7.11"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/dca.rs
+++ b/integration-tests/src/dca.rs
@@ -118,6 +118,7 @@ fn buy_schedule_should_be_retried_multiple_times_then_terminated() {
 			period: 1u32,
 			total_amount: dca_budget,
 			max_retries: None,
+			stability_threshold: None,
 			order: Order::Buy {
 				asset_in: HDX,
 				asset_out: DAI,
@@ -571,6 +572,7 @@ fn sell_schedule_should_be_terminated_after_retries() {
 			period: 1u32,
 			total_amount: dca_budget,
 			max_retries: None,
+			stability_threshold: None,
 			order: Order::Sell {
 				asset_in: HDX,
 				asset_out: DAI,
@@ -1229,6 +1231,7 @@ fn schedule_fake_with_buy_order(
 		period: 2u32,
 		total_amount: budget,
 		max_retries: None,
+		stability_threshold: None,
 		order: Order::Buy {
 			asset_in,
 			asset_out,
@@ -1256,6 +1259,7 @@ fn schedule_fake_with_sell_order(
 		period: 3u32,
 		total_amount,
 		max_retries: None,
+		stability_threshold: None,
 		order: Order::Sell {
 			asset_in,
 			asset_out,

--- a/integration-tests/src/dca.rs
+++ b/integration-tests/src/dca.rs
@@ -117,6 +117,7 @@ fn buy_schedule_should_be_retried_multiple_times_then_terminated() {
 			owner: AccountId::from(ALICE),
 			period: 1u32,
 			total_amount: dca_budget,
+			max_retries: None,
 			order: Order::Buy {
 				asset_in: HDX,
 				asset_out: DAI,
@@ -569,6 +570,7 @@ fn sell_schedule_should_be_terminated_after_retries() {
 			owner: AccountId::from(ALICE),
 			period: 1u32,
 			total_amount: dca_budget,
+			max_retries: None,
 			order: Order::Sell {
 				asset_in: HDX,
 				asset_out: DAI,
@@ -1226,6 +1228,7 @@ fn schedule_fake_with_buy_order(
 		owner: AccountId::from(ALICE),
 		period: 2u32,
 		total_amount: budget,
+		max_retries: None,
 		order: Order::Buy {
 			asset_in,
 			asset_out,
@@ -1252,6 +1255,7 @@ fn schedule_fake_with_sell_order(
 		owner: AccountId::from(owner),
 		period: 3u32,
 		total_amount,
+		max_retries: None,
 		order: Order::Sell {
 			asset_in,
 			asset_out,

--- a/integration-tests/src/dca.rs
+++ b/integration-tests/src/dca.rs
@@ -119,12 +119,12 @@ fn buy_schedule_should_be_retried_multiple_times_then_terminated() {
 			total_amount: dca_budget,
 			max_retries: None,
 			stability_threshold: None,
+			slippage: Some(Permill::from_percent(5)),
 			order: Order::Buy {
 				asset_in: HDX,
 				asset_out: DAI,
 				amount_out,
 				max_limit: Balance::MIN,
-				slippage: Some(Permill::from_percent(5)),
 				route: create_bounded_vec(vec![Trade {
 					pool: PoolType::Omnipool,
 					asset_in: HDX,
@@ -573,12 +573,12 @@ fn sell_schedule_should_be_terminated_after_retries() {
 			total_amount: dca_budget,
 			max_retries: None,
 			stability_threshold: None,
+			slippage: Some(Permill::from_percent(1)),
 			order: Order::Sell {
 				asset_in: HDX,
 				asset_out: DAI,
 				amount_in: amount_to_sell,
 				min_limit: Balance::MAX,
-				slippage: Some(Permill::from_percent(1)),
 				route: create_bounded_vec(vec![Trade {
 					pool: PoolType::Omnipool,
 					asset_in: HDX,
@@ -1232,12 +1232,12 @@ fn schedule_fake_with_buy_order(
 		total_amount: budget,
 		max_retries: None,
 		stability_threshold: None,
+		slippage: Some(Permill::from_percent(5)),
 		order: Order::Buy {
 			asset_in,
 			asset_out,
 			amount_out: amount,
 			max_limit: Balance::MAX,
-			slippage: Some(Permill::from_percent(5)),
 			route: create_bounded_vec(vec![Trade {
 				pool: PoolType::Omnipool,
 				asset_in,
@@ -1260,12 +1260,12 @@ fn schedule_fake_with_sell_order(
 		total_amount,
 		max_retries: None,
 		stability_threshold: None,
+		slippage: Some(Permill::from_percent(10)),
 		order: Order::Sell {
 			asset_in,
 			asset_out,
 			amount_in: amount,
 			min_limit: Balance::MIN,
-			slippage: Some(Permill::from_percent(10)),
 			route: create_bounded_vec(vec![Trade {
 				pool: PoolType::Omnipool,
 				asset_in,

--- a/integration-tests/src/dca.rs
+++ b/integration-tests/src/dca.rs
@@ -124,7 +124,7 @@ fn buy_schedule_should_be_retried_multiple_times_then_terminated() {
 				asset_in: HDX,
 				asset_out: DAI,
 				amount_out,
-				max_limit: Balance::MIN,
+				max_amount_in: Balance::MIN,
 				route: create_bounded_vec(vec![Trade {
 					pool: PoolType::Omnipool,
 					asset_in: HDX,
@@ -578,7 +578,7 @@ fn sell_schedule_should_be_terminated_after_retries() {
 				asset_in: HDX,
 				asset_out: DAI,
 				amount_in: amount_to_sell,
-				min_limit: Balance::MAX,
+				min_amount_out: Balance::MAX,
 				route: create_bounded_vec(vec![Trade {
 					pool: PoolType::Omnipool,
 					asset_in: HDX,
@@ -1237,7 +1237,7 @@ fn schedule_fake_with_buy_order(
 			asset_in,
 			asset_out,
 			amount_out: amount,
-			max_limit: Balance::MAX,
+			max_amount_in: Balance::MAX,
 			route: create_bounded_vec(vec![Trade {
 				pool: PoolType::Omnipool,
 				asset_in,
@@ -1265,7 +1265,7 @@ fn schedule_fake_with_sell_order(
 			asset_in,
 			asset_out,
 			amount_in: amount,
-			min_limit: Balance::MIN,
+			min_amount_out: Balance::MIN,
 			route: create_bounded_vec(vec![Trade {
 				pool: PoolType::Omnipool,
 				asset_in,

--- a/pallets/dca/Cargo.toml
+++ b/pallets/dca/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-dca'
-version = '1.0.1'
+version = '1.1.0'
 description = 'A pallet to manage DCA scheduling'
 authors = ['GalacticCouncil']
 edition = '2021'

--- a/pallets/dca/src/benchmarks.rs
+++ b/pallets/dca/src/benchmarks.rs
@@ -50,6 +50,7 @@ fn schedule_fake<T: Config + pallet_route_executor::Config + pallet_omnipool::Co
 		period: 3u32.into(),
 		total_amount: 1100 * ONE,
 		max_retries: None,
+		stability_threshold: None,
 		order: Order::Buy {
 			asset_in,
 			asset_out,
@@ -84,6 +85,7 @@ fn schedule_buy_fake<T: Config + pallet_route_executor::Config + pallet_omnipool
 		period: 3u32.into(),
 		total_amount: 2000 * ONE,
 		max_retries: None,
+		stability_threshold: None,
 		order: Order::Buy {
 			asset_in,
 			asset_out,
@@ -111,6 +113,7 @@ fn schedule_sell_fake<T: Config + pallet_route_executor::Config + pallet_omnipoo
 		period: 3u32.into(),
 		total_amount: 2000 * ONE,
 		max_retries: None,
+		stability_threshold: None,
 		order: Order::Sell {
 			asset_in,
 			asset_out,

--- a/pallets/dca/src/benchmarks.rs
+++ b/pallets/dca/src/benchmarks.rs
@@ -49,6 +49,7 @@ fn schedule_fake<T: Config + pallet_route_executor::Config + pallet_omnipool::Co
 		owner,
 		period: 3u32.into(),
 		total_amount: 1100 * ONE,
+		max_retries: None,
 		order: Order::Buy {
 			asset_in,
 			asset_out,
@@ -82,6 +83,7 @@ fn schedule_buy_fake<T: Config + pallet_route_executor::Config + pallet_omnipool
 		owner,
 		period: 3u32.into(),
 		total_amount: 2000 * ONE,
+		max_retries: None,
 		order: Order::Buy {
 			asset_in,
 			asset_out,
@@ -108,6 +110,7 @@ fn schedule_sell_fake<T: Config + pallet_route_executor::Config + pallet_omnipoo
 		owner,
 		period: 3u32.into(),
 		total_amount: 2000 * ONE,
+		max_retries: None,
 		order: Order::Sell {
 			asset_in,
 			asset_out,

--- a/pallets/dca/src/benchmarks.rs
+++ b/pallets/dca/src/benchmarks.rs
@@ -56,7 +56,7 @@ fn schedule_fake<T: Config + pallet_route_executor::Config + pallet_omnipool::Co
 			asset_in,
 			asset_out,
 			amount_out: amount,
-			max_limit: Balance::MAX,
+			max_amount_in: Balance::MAX,
 			route: create_bounded_vec::<T>(vec![Trade {
 				pool: PoolType::Omnipool,
 				asset_in,
@@ -91,7 +91,7 @@ fn schedule_buy_fake<T: Config + pallet_route_executor::Config + pallet_omnipool
 			asset_in,
 			asset_out,
 			amount_out: amount,
-			max_limit: Balance::MAX,
+			max_amount_in: Balance::MAX,
 			route: create_bounded_vec::<T>(vec![Trade {
 				pool: PoolType::Omnipool,
 				asset_in,
@@ -119,7 +119,7 @@ fn schedule_sell_fake<T: Config + pallet_route_executor::Config + pallet_omnipoo
 			asset_in,
 			asset_out,
 			amount_in: amount,
-			min_limit: Balance::MIN,
+			min_amount_out: Balance::MIN,
 			route: create_bounded_vec::<T>(vec![Trade {
 				pool: PoolType::Omnipool,
 				asset_in,

--- a/pallets/dca/src/benchmarks.rs
+++ b/pallets/dca/src/benchmarks.rs
@@ -51,12 +51,12 @@ fn schedule_fake<T: Config + pallet_route_executor::Config + pallet_omnipool::Co
 		total_amount: 1100 * ONE,
 		max_retries: None,
 		stability_threshold: None,
+		slippage: Some(Permill::from_percent(15)),
 		order: Order::Buy {
 			asset_in,
 			asset_out,
 			amount_out: amount,
 			max_limit: Balance::MAX,
-			slippage: Some(Permill::from_percent(15)),
 			route: create_bounded_vec::<T>(vec![Trade {
 				pool: PoolType::Omnipool,
 				asset_in,
@@ -86,12 +86,12 @@ fn schedule_buy_fake<T: Config + pallet_route_executor::Config + pallet_omnipool
 		total_amount: 2000 * ONE,
 		max_retries: None,
 		stability_threshold: None,
+		slippage: Some(Permill::from_percent(15)),
 		order: Order::Buy {
 			asset_in,
 			asset_out,
 			amount_out: amount,
 			max_limit: Balance::MAX,
-			slippage: Some(Permill::from_percent(15)),
 			route: create_bounded_vec::<T>(vec![Trade {
 				pool: PoolType::Omnipool,
 				asset_in,
@@ -114,12 +114,12 @@ fn schedule_sell_fake<T: Config + pallet_route_executor::Config + pallet_omnipoo
 		total_amount: 2000 * ONE,
 		max_retries: None,
 		stability_threshold: None,
+		slippage: Some(Permill::from_percent(30)),
 		order: Order::Sell {
 			asset_in,
 			asset_out,
 			amount_in: amount,
 			min_limit: Balance::MIN,
-			slippage: Some(Permill::from_percent(30)),
 			route: create_bounded_vec::<T>(vec![Trade {
 				pool: PoolType::Omnipool,
 				asset_in,

--- a/pallets/dca/src/lib.rs
+++ b/pallets/dca/src/lib.rs
@@ -557,7 +557,6 @@ where
 				asset_out,
 				amount_in,
 				min_limit,
-				slippage,
 				route,
 			} => {
 				let remaining_amount =
@@ -567,7 +566,7 @@ where
 				Self::unallocate_amount(schedule_id, schedule, amount_to_sell)?;
 
 				let (estimated_amount_out, slippage_amount) =
-					Self::calculate_last_block_slippage(*asset_out, *asset_in, amount_to_sell, *slippage)?;
+					Self::calculate_last_block_slippage(*asset_out, *asset_in, amount_to_sell, schedule.slippage)?;
 				let last_block_slippage_min_limit = estimated_amount_out
 					.checked_sub(slippage_amount)
 					.ok_or(ArithmeticError::Overflow)?;
@@ -605,7 +604,6 @@ where
 				asset_in,
 				asset_out,
 				amount_out,
-				slippage,
 				max_limit,
 				route,
 			} => {
@@ -614,7 +612,7 @@ where
 				Self::unallocate_amount(schedule_id, schedule, amount_in)?;
 
 				let (estimated_amount_in, slippage_amount) =
-					Self::calculate_last_block_slippage(*asset_in, *asset_out, *amount_out, *slippage)?;
+					Self::calculate_last_block_slippage(*asset_in, *asset_out, *amount_out, schedule.slippage)?;
 				let last_block_slippage_max_limit = estimated_amount_in
 					.checked_add(slippage_amount)
 					.ok_or(ArithmeticError::Overflow)?;

--- a/pallets/dca/src/lib.rs
+++ b/pallets/dca/src/lib.rs
@@ -698,10 +698,8 @@ where
 	) -> DispatchResult {
 		let number_of_retries = Self::retries_on_error(schedule_id);
 
-		ensure!(
-			number_of_retries < T::MaxNumberOfRetriesOnError::get(),
-			Error::<T>::MaxRetryReached
-		);
+		let max_retries = schedule.max_retries.unwrap_or_else(T::MaxNumberOfRetriesOnError::get);
+		ensure!(number_of_retries < max_retries, Error::<T>::MaxRetryReached);
 
 		RetriesOnError::<T>::mutate(schedule_id, |retry| -> DispatchResult {
 			retry.saturating_inc();

--- a/pallets/dca/src/lib.rs
+++ b/pallets/dca/src/lib.rs
@@ -734,8 +734,7 @@ where
 		};
 
 		let max_allowed_diff = schedule
-			.order
-			.get_slippage()
+			.stability_threshold
 			.unwrap_or_else(T::MaxPriceDifferenceBetweenBlocks::get);
 
 		let max_allowed = FixedU128::from(max_allowed_diff);

--- a/pallets/dca/src/lib.rs
+++ b/pallets/dca/src/lib.rs
@@ -663,7 +663,8 @@ where
 		let remaining_amount: Balance =
 			RemainingAmounts::<T>::get(schedule_id).defensive_ok_or(Error::<T>::InvalidState)?;
 		let transaction_fee = Self::get_transaction_fee(&schedule.order)?;
-		if remaining_amount <= transaction_fee {
+		let min_amount_for_replanning = transaction_fee.checked_mul(5).ok_or(ArithmeticError::Overflow)?;
+		if remaining_amount <= min_amount_for_replanning {
 			Self::complete_schedule(schedule_id, schedule);
 			return Ok(());
 		}

--- a/pallets/dca/src/lib.rs
+++ b/pallets/dca/src/lib.rs
@@ -556,7 +556,7 @@ where
 				asset_in,
 				asset_out,
 				amount_in,
-				min_limit,
+				min_amount_out,
 				route,
 			} => {
 				let remaining_amount =
@@ -577,8 +577,8 @@ where
 				let last_trade = trade_amounts.last().defensive_ok_or(Error::<T>::InvalidState)?;
 				let amount_out = last_trade.amount_out;
 
-				if *min_limit > last_block_slippage_min_limit {
-					ensure!(amount_out >= (*min_limit).into(), Error::<T>::TradeLimitReached);
+				if *min_amount_out > last_block_slippage_min_limit {
+					ensure!(amount_out >= (*min_amount_out).into(), Error::<T>::TradeLimitReached);
 				} else {
 					ensure!(
 						amount_out >= last_block_slippage_min_limit.into(),
@@ -604,7 +604,7 @@ where
 				asset_in,
 				asset_out,
 				amount_out,
-				max_limit,
+				max_amount_in,
 				route,
 			} => {
 				let amount_in = Self::get_amount_in_for_buy(amount_out, route)?;
@@ -617,8 +617,8 @@ where
 					.checked_add(slippage_amount)
 					.ok_or(ArithmeticError::Overflow)?;
 
-				if *max_limit < last_block_slippage_max_limit {
-					ensure!(amount_in <= *max_limit, Error::<T>::TradeLimitReached);
+				if *max_amount_in < last_block_slippage_max_limit {
+					ensure!(amount_in <= *max_amount_in, Error::<T>::TradeLimitReached);
 				} else {
 					ensure!(
 						amount_in <= last_block_slippage_max_limit,

--- a/pallets/dca/src/tests/mod.rs
+++ b/pallets/dca/src/tests/mod.rs
@@ -23,6 +23,7 @@ struct ScheduleBuilder {
 	pub order: Option<Order<AssetId>>,
 	pub total_amount: Option<Balance>,
 	pub max_retries: Option<Option<u8>>,
+	pub slippage: Option<Option<Permill>>,
 	pub stability_threshold: Option<Option<Permill>>,
 }
 
@@ -32,6 +33,7 @@ impl ScheduleBuilder {
 			owner: Some(ALICE),
 			period: Some(ONE_HUNDRED_BLOCKS),
 			stability_threshold: Some(None),
+			slippage: Some(None),
 			total_amount: Some(1000 * ONE),
 			max_retries: Some(None),
 			order: Some(Order::Buy {
@@ -39,7 +41,6 @@ impl ScheduleBuilder {
 				asset_out: BTC,
 				amount_out: ONE,
 				max_limit: 2 * ONE,
-				slippage: None,
 				route: create_bounded_vec(vec![Trade {
 					pool: PoolType::Omnipool,
 					asset_in: HDX,
@@ -74,6 +75,11 @@ impl ScheduleBuilder {
 		self
 	}
 
+	fn with_slippage(mut self, slippage: Option<Permill>) -> ScheduleBuilder {
+		self.slippage = Some(slippage);
+		self
+	}
+
 	fn with_max_retries(mut self, max_retries: Option<u8>) -> ScheduleBuilder {
 		self.max_retries = Some(max_retries);
 		self
@@ -84,6 +90,7 @@ impl ScheduleBuilder {
 			owner: self.owner.unwrap(),
 			period: self.period.unwrap(),
 			stability_threshold: self.stability_threshold.unwrap(),
+			slippage: self.slippage.unwrap(),
 			total_amount: self.total_amount.unwrap(),
 			max_retries: self.max_retries.unwrap(),
 			order: self.order.unwrap(),

--- a/pallets/dca/src/tests/mod.rs
+++ b/pallets/dca/src/tests/mod.rs
@@ -40,7 +40,7 @@ impl ScheduleBuilder {
 				asset_in: HDX,
 				asset_out: BTC,
 				amount_out: ONE,
-				max_limit: 2 * ONE,
+				max_amount_in: 2 * ONE,
 				route: create_bounded_vec(vec![Trade {
 					pool: PoolType::Omnipool,
 					asset_in: HDX,

--- a/pallets/dca/src/tests/mod.rs
+++ b/pallets/dca/src/tests/mod.rs
@@ -22,6 +22,7 @@ struct ScheduleBuilder {
 	pub period: Option<BlockNumber>,
 	pub order: Option<Order<AssetId>>,
 	pub total_amount: Option<Balance>,
+	pub max_retries: Option<Option<u8>>,
 }
 
 impl ScheduleBuilder {
@@ -30,6 +31,7 @@ impl ScheduleBuilder {
 			owner: Some(ALICE),
 			period: Some(ONE_HUNDRED_BLOCKS),
 			total_amount: Some(1000 * ONE),
+			max_retries: Some(None),
 			order: Some(Order::Buy {
 				asset_in: HDX,
 				asset_out: BTC,
@@ -65,11 +67,17 @@ impl ScheduleBuilder {
 		self
 	}
 
+	fn with_max_retries(mut self, max_retries: Option<u8>) -> ScheduleBuilder {
+		self.max_retries = Some(max_retries);
+		self
+	}
+
 	fn build(self) -> Schedule<AccountId, AssetId, BlockNumber> {
 		Schedule {
 			owner: self.owner.unwrap(),
 			period: self.period.unwrap(),
 			total_amount: self.total_amount.unwrap(),
+			max_retries: self.max_retries.unwrap(),
 			order: self.order.unwrap(),
 		}
 	}

--- a/pallets/dca/src/tests/mod.rs
+++ b/pallets/dca/src/tests/mod.rs
@@ -3,7 +3,7 @@ use crate::{Balance, Order, Schedule, ScheduleId};
 use hydradx_traits::router::PoolType;
 use pallet_route_executor::Trade;
 use sp_runtime::traits::ConstU32;
-use sp_runtime::BoundedVec;
+use sp_runtime::{BoundedVec, Permill};
 
 pub mod mock;
 pub mod on_initialize;
@@ -23,6 +23,7 @@ struct ScheduleBuilder {
 	pub order: Option<Order<AssetId>>,
 	pub total_amount: Option<Balance>,
 	pub max_retries: Option<Option<u8>>,
+	pub stability_threshold: Option<Option<Permill>>,
 }
 
 impl ScheduleBuilder {
@@ -30,6 +31,7 @@ impl ScheduleBuilder {
 		ScheduleBuilder {
 			owner: Some(ALICE),
 			period: Some(ONE_HUNDRED_BLOCKS),
+			stability_threshold: Some(None),
 			total_amount: Some(1000 * ONE),
 			max_retries: Some(None),
 			order: Some(Order::Buy {
@@ -67,6 +69,11 @@ impl ScheduleBuilder {
 		self
 	}
 
+	fn with_price_stability_threshold(mut self, treshold: Option<Permill>) -> ScheduleBuilder {
+		self.stability_threshold = Some(treshold);
+		self
+	}
+
 	fn with_max_retries(mut self, max_retries: Option<u8>) -> ScheduleBuilder {
 		self.max_retries = Some(max_retries);
 		self
@@ -76,6 +83,7 @@ impl ScheduleBuilder {
 		Schedule {
 			owner: self.owner.unwrap(),
 			period: self.period.unwrap(),
+			stability_threshold: self.stability_threshold.unwrap(),
 			total_amount: self.total_amount.unwrap(),
 			max_retries: self.max_retries.unwrap(),
 			order: self.order.unwrap(),

--- a/pallets/dca/src/tests/on_initialize.rs
+++ b/pallets/dca/src/tests/on_initialize.rs
@@ -53,7 +53,6 @@ fn successfull_sell_dca_execution_should_emit_trade_executed_event() {
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -103,12 +102,12 @@ fn successfull_buy_dca_execution_should_emit_trade_executed_event() {
 			let schedule = ScheduleBuilder::new()
 				.with_total_amount(total_amount)
 				.with_period(ONE_HUNDRED_BLOCKS)
+				.with_slippage(Some(Permill::from_percent(20)))
 				.with_order(Order::Buy {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: amount_to_buy,
 					max_limit,
-					slippage: Some(Permill::from_percent(20)),
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -163,7 +162,6 @@ fn one_sell_dca_execution_should_unreserve_amount_in() {
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -229,7 +227,6 @@ fn sell_schedule_should_sell_remaining_when_there_is_not_enough_left() {
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -296,7 +293,6 @@ fn sell_schedule_should_continue_when_there_is_exact_amount_in_left_as_remaining
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -339,12 +335,12 @@ fn one_buy_dca_execution_should_unreserve_exact_amount_in() {
 			let schedule = ScheduleBuilder::new()
 				.with_total_amount(total_amount)
 				.with_period(ONE_HUNDRED_BLOCKS)
+				.with_slippage(Some(Permill::from_percent(20)))
 				.with_order(Order::Buy {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: amount_to_buy,
 					max_limit,
-					slippage: Some(Permill::from_percent(20)),
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -389,13 +385,13 @@ fn one_buy_dca_execution_should_calculate_exact_amount_in_when_multiple_pools_in
 
 			let schedule = ScheduleBuilder::new()
 				.with_total_amount(total_amount)
+				.with_slippage(Some(Permill::from_percent(20)))
 				.with_period(ONE_HUNDRED_BLOCKS)
 				.with_order(Order::Buy {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: amount_to_buy,
 					max_limit,
-					slippage: Some(Permill::from_percent(20)),
 					route: create_bounded_vec(vec![
 						Trade {
 							pool: PoolType::Omnipool,
@@ -460,7 +456,6 @@ fn full_sell_dca_should_be_completed_with_selling_leftover_in_last_trade() {
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -505,7 +500,6 @@ fn full_sell_dca_should_be_completed_when_some_successfull_dca_execution_happene
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -547,12 +541,12 @@ fn full_buy_dca_should_be_completed_when_some_successfull_dca_execution_happened
 			let schedule = ScheduleBuilder::new()
 				.with_total_amount(total_amount)
 				.with_period(ONE_HUNDRED_BLOCKS)
+				.with_slippage(Some(Permill::from_percent(20)))
 				.with_order(Order::Buy {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: amount_to_buy,
 					max_limit: Balance::MAX,
-					slippage: Some(Permill::from_percent(20)),
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -599,7 +593,6 @@ fn full_sell_dca_should_be_completed_for_multiple_users() {
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -617,7 +610,6 @@ fn full_sell_dca_should_be_completed_for_multiple_users() {
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -676,7 +668,6 @@ fn multiple_sell_dca_should_be_completed_for_one_user() {
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -728,7 +719,6 @@ fn full_sell_dca_should_be_completed_when_exact_total_amount_specified_for_the_t
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -767,13 +757,13 @@ fn full_buy_dca_should_be_completed_when_some_execution_is_successfull_but_not_e
 
 			let schedule = ScheduleBuilder::new()
 				.with_total_amount(total_amount)
+				.with_slippage(Some(Permill::from_percent(20)))
 				.with_period(ONE_HUNDRED_BLOCKS)
 				.with_order(Order::Buy {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: amount_to_buy,
 					max_limit: Balance::MAX,
-					slippage: Some(Permill::from_percent(20)),
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -820,12 +810,12 @@ fn full_buy_dca_should_be_completed_without_leftover_fees_are_included_in_budget
 			let schedule = ScheduleBuilder::new()
 				.with_total_amount(total_amount)
 				.with_period(ONE_HUNDRED_BLOCKS)
+				.with_slippage(Some(Permill::from_percent(20)))
 				.with_order(Order::Buy {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: amount_to_buy,
 					max_limit: Balance::MAX,
-					slippage: Some(Permill::from_percent(20)),
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -872,7 +862,6 @@ fn one_buy_dca_execution_should_use_default_max_price_diff_for_max_limit_calcula
 					asset_out: BTC,
 					amount_out: amount_to_buy,
 					max_limit: Balance::MAX,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -918,12 +907,12 @@ fn schedule_is_planned_for_next_block_when_one_execution_finished() {
 
 			let schedule = ScheduleBuilder::new()
 				.with_period(ONE_HUNDRED_BLOCKS)
+				.with_slippage(Some(Permill::from_percent(20)))
 				.with_order(Order::Buy {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: 10 * ONE,
 					max_limit: 10 * ONE,
-					slippage: Some(Permill::from_percent(20)),
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -962,7 +951,6 @@ fn schedule_is_planned_with_period_when_block_has_already_planned_schedule() {
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -1009,7 +997,6 @@ fn buy_dca_schedule_should_be_retried_when_trade_limit_error_happens() {
 					asset_out: BTC,
 					amount_out: CALCULATED_AMOUNT_IN_FOR_OMNIPOOL_BUY,
 					max_limit: 5 * ONE,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -1064,7 +1051,6 @@ fn sell_dca_schedule_should_be_retried_when_trade_limit_error_happens() {
 					asset_out: BTC,
 					amount_in: *AMOUNT_OUT_FOR_OMNIPOOL_SELL,
 					min_limit: Balance::MAX,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -1118,7 +1104,6 @@ fn dca_trade_unallocation_should_be_rolled_back_when_trade_fails() {
 					asset_out: BTC,
 					amount_out: CALCULATED_AMOUNT_IN_FOR_OMNIPOOL_BUY,
 					max_limit: 5 * ONE,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -1165,7 +1150,6 @@ fn dca_schedule_should_terminate_when_error_is_not_configured_to_continue_on() {
 					asset_out: BTC,
 					amount_in: ONE,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: FORBIDDEN_ASSET,
@@ -1204,7 +1188,6 @@ fn dca_schedule_should_continue_on_multiple_failures_then_terminated() {
 					asset_out: BTC,
 					amount_out: CALCULATED_AMOUNT_IN_FOR_OMNIPOOL_BUY,
 					max_limit: 5 * ONE,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1250,7 +1233,6 @@ fn dca_schedule_should_use_specified_max_retry_count() {
 					asset_out: BTC,
 					amount_out: CALCULATED_AMOUNT_IN_FOR_OMNIPOOL_BUY,
 					max_limit: 5 * ONE,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1304,7 +1286,6 @@ fn buy_dca_schedule_should_continue_on_slippage_error() {
 					asset_out: BTC,
 					amount_out: CALCULATED_AMOUNT_IN_FOR_OMNIPOOL_BUY,
 					max_limit: Balance::MAX,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1345,7 +1326,6 @@ fn sell_dca_schedule_continue_on_slippage_error() {
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1386,7 +1366,6 @@ fn dca_schedule_retry_should_be_reset_when_successfull_trade_after_failed_ones()
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1429,12 +1408,12 @@ fn execution_fee_should_be_taken_from_user_in_sold_currency_in_case_of_successfu
 			let schedule = ScheduleBuilder::new()
 				.with_period(ONE_HUNDRED_BLOCKS)
 				.with_total_amount(budget)
+				.with_slippage(Some(Permill::from_percent(20)))
 				.with_order(Order::Buy {
 					asset_in: DAI,
 					asset_out: BTC,
 					amount_out: 10 * ONE,
 					max_limit: 50 * ONE,
-					slippage: Some(Permill::from_percent(20)),
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: DAI,
@@ -1479,7 +1458,6 @@ fn execution_fee_should_be_still_taken_from_user_in_sold_currency_in_case_of_fai
 					asset_out: BTC,
 					amount_out: CALCULATED_AMOUNT_IN_FOR_OMNIPOOL_BUY,
 					max_limit: 5 * ONE,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: DAI,
@@ -1524,7 +1502,6 @@ fn execution_fee_should_be_taken_from_user_in_sold_currency_in_case_of_successfu
 					asset_out: BTC,
 					amount_in,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: DAI,
@@ -1571,7 +1548,6 @@ fn sell_dca_native_execution_fee_should_be_taken_and_sent_to_treasury() {
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1610,12 +1586,12 @@ fn buy_dca_native_execution_fee_should_be_taken_and_sent_to_treasury() {
 			let budget = 1000 * ONE;
 			let schedule = ScheduleBuilder::new()
 				.with_period(ONE_HUNDRED_BLOCKS)
+				.with_slippage(Some(Permill::from_percent(20)))
 				.with_order(Order::Buy {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: 10 * ONE,
 					max_limit: 10 * ONE,
-					slippage: Some(Permill::from_percent(20)),
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1656,12 +1632,12 @@ fn slippage_limit_should_be_used_for_buy_dca_when_it_is_smaller_than_specified_t
 
 			let schedule = ScheduleBuilder::new()
 				.with_period(ONE_HUNDRED_BLOCKS)
+				.with_slippage(Some(Permill::from_percent(1)))
 				.with_order(Order::Buy {
 					asset_in: HDX,
 					asset_out: DAI,
 					amount_out: buy_amount,
 					max_limit: Balance::MAX,
-					slippage: Some(Permill::from_percent(1)),
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1705,7 +1681,6 @@ fn one_sell_dca_execution_should_be_rescheduled_when_price_diff_is_more_than_max
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1769,7 +1744,6 @@ fn one_sell_dca_execution_should_be_rescheduled_when_price_diff_is_more_than_use
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1832,7 +1806,6 @@ fn one_buy_dca_execution_should_be_rescheduled_when_price_diff_is_more_than_max_
 					asset_out: BTC,
 					amount_out: amount_to_buy,
 					max_limit,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1875,12 +1848,12 @@ fn specified_slippage_should_be_used_in_circuit_breaker_price_check() {
 			let schedule = ScheduleBuilder::new()
 				.with_total_amount(total_amount)
 				.with_period(ONE_HUNDRED_BLOCKS)
+				.with_slippage(Some(Permill::from_percent(9)))
 				.with_order(Order::Buy {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: amount_to_buy,
 					max_limit,
-					slippage: Some(Permill::from_percent(9)),
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1932,7 +1905,6 @@ fn dca_should_be_terminated_when_dca_cannot_be_planned_due_to_not_free_blocks() 
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1986,7 +1958,6 @@ fn dca_should_be_terminated_when_price_change_is_big_but_no_free_blocks_to_repla
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -2032,7 +2003,6 @@ fn dca_should_be_executed_and_replanned_through_multiple_blocks_when_all_consque
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -2099,7 +2069,6 @@ fn dca_sell_schedule_should_be_completed_after_one_trade_when_total_amount_is_eq
 					asset_out: BTC,
 					amount_in,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -2139,7 +2108,6 @@ fn dca_sell_schedule_should_be_terminated_when_schedule_allocation_is_more_than_
 					asset_out: BTC,
 					amount_in,
 					min_limit: 5 * ONE,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -2182,7 +2150,6 @@ fn schedules_are_purged_when_the_block_is_over() {
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -2237,7 +2204,6 @@ fn sell_schedule_should_be_completed_when_only_5_transaction_fee_left() {
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -2281,7 +2247,6 @@ fn sell_schedule_should_be_replanned_when_more_than_5_transaction_fee_left_for_n
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -2326,7 +2291,6 @@ fn execution_is_still_successfull_when_no_parent_hash_present() {
 					asset_out: BTC,
 					amount_in: amount_to_sell,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,

--- a/pallets/dca/src/tests/on_initialize.rs
+++ b/pallets/dca/src/tests/on_initialize.rs
@@ -52,7 +52,7 @@ fn successfull_sell_dca_execution_should_emit_trade_executed_event() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -107,7 +107,7 @@ fn successfull_buy_dca_execution_should_emit_trade_executed_event() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: amount_to_buy,
-					max_limit,
+					max_amount_in: max_limit,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -161,7 +161,7 @@ fn one_sell_dca_execution_should_unreserve_amount_in() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -226,7 +226,7 @@ fn sell_schedule_should_sell_remaining_when_there_is_not_enough_left() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -292,7 +292,7 @@ fn sell_schedule_should_continue_when_there_is_exact_amount_in_left_as_remaining
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -340,7 +340,7 @@ fn one_buy_dca_execution_should_unreserve_exact_amount_in() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: amount_to_buy,
-					max_limit,
+					max_amount_in: max_limit,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -391,7 +391,7 @@ fn one_buy_dca_execution_should_calculate_exact_amount_in_when_multiple_pools_in
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: amount_to_buy,
-					max_limit,
+					max_amount_in: max_limit,
 					route: create_bounded_vec(vec![
 						Trade {
 							pool: PoolType::Omnipool,
@@ -455,7 +455,7 @@ fn full_sell_dca_should_be_completed_with_selling_leftover_in_last_trade() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -499,7 +499,7 @@ fn full_sell_dca_should_be_completed_when_some_successfull_dca_execution_happene
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -546,7 +546,7 @@ fn full_buy_dca_should_be_completed_when_some_successfull_dca_execution_happened
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: amount_to_buy,
-					max_limit: Balance::MAX,
+					max_amount_in: Balance::MAX,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -592,7 +592,7 @@ fn full_sell_dca_should_be_completed_for_multiple_users() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -609,7 +609,7 @@ fn full_sell_dca_should_be_completed_for_multiple_users() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -667,7 +667,7 @@ fn multiple_sell_dca_should_be_completed_for_one_user() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -718,7 +718,7 @@ fn full_sell_dca_should_be_completed_when_exact_total_amount_specified_for_the_t
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -763,7 +763,7 @@ fn full_buy_dca_should_be_completed_when_some_execution_is_successfull_but_not_e
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: amount_to_buy,
-					max_limit: Balance::MAX,
+					max_amount_in: Balance::MAX,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -815,7 +815,7 @@ fn full_buy_dca_should_be_completed_without_leftover_fees_are_included_in_budget
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: amount_to_buy,
-					max_limit: Balance::MAX,
+					max_amount_in: Balance::MAX,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -861,7 +861,7 @@ fn one_buy_dca_execution_should_use_default_max_price_diff_for_max_limit_calcula
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: amount_to_buy,
-					max_limit: Balance::MAX,
+					max_amount_in: Balance::MAX,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -912,7 +912,7 @@ fn schedule_is_planned_for_next_block_when_one_execution_finished() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: 10 * ONE,
-					max_limit: 10 * ONE,
+					max_amount_in: 10 * ONE,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -950,7 +950,7 @@ fn schedule_is_planned_with_period_when_block_has_already_planned_schedule() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -996,7 +996,7 @@ fn buy_dca_schedule_should_be_retried_when_trade_limit_error_happens() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: CALCULATED_AMOUNT_IN_FOR_OMNIPOOL_BUY,
-					max_limit: 5 * ONE,
+					max_amount_in: 5 * ONE,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -1050,7 +1050,7 @@ fn sell_dca_schedule_should_be_retried_when_trade_limit_error_happens() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: *AMOUNT_OUT_FOR_OMNIPOOL_SELL,
-					min_limit: Balance::MAX,
+					min_amount_out: Balance::MAX,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -1103,7 +1103,7 @@ fn dca_trade_unallocation_should_be_rolled_back_when_trade_fails() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: CALCULATED_AMOUNT_IN_FOR_OMNIPOOL_BUY,
-					max_limit: 5 * ONE,
+					max_amount_in: 5 * ONE,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -1149,7 +1149,7 @@ fn dca_schedule_should_terminate_when_error_is_not_configured_to_continue_on() {
 					asset_in: FORBIDDEN_ASSET,
 					asset_out: BTC,
 					amount_in: ONE,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: FORBIDDEN_ASSET,
@@ -1187,7 +1187,7 @@ fn dca_schedule_should_continue_on_multiple_failures_then_terminated() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: CALCULATED_AMOUNT_IN_FOR_OMNIPOOL_BUY,
-					max_limit: 5 * ONE,
+					max_amount_in: 5 * ONE,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1232,7 +1232,7 @@ fn dca_schedule_should_use_specified_max_retry_count() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: CALCULATED_AMOUNT_IN_FOR_OMNIPOOL_BUY,
-					max_limit: 5 * ONE,
+					max_amount_in: 5 * ONE,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1285,7 +1285,7 @@ fn buy_dca_schedule_should_continue_on_slippage_error() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: CALCULATED_AMOUNT_IN_FOR_OMNIPOOL_BUY,
-					max_limit: Balance::MAX,
+					max_amount_in: Balance::MAX,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1325,7 +1325,7 @@ fn sell_dca_schedule_continue_on_slippage_error() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1365,7 +1365,7 @@ fn dca_schedule_retry_should_be_reset_when_successfull_trade_after_failed_ones()
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1413,7 +1413,7 @@ fn execution_fee_should_be_taken_from_user_in_sold_currency_in_case_of_successfu
 					asset_in: DAI,
 					asset_out: BTC,
 					amount_out: 10 * ONE,
-					max_limit: 50 * ONE,
+					max_amount_in: 50 * ONE,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: DAI,
@@ -1457,7 +1457,7 @@ fn execution_fee_should_be_still_taken_from_user_in_sold_currency_in_case_of_fai
 					asset_in: DAI,
 					asset_out: BTC,
 					amount_out: CALCULATED_AMOUNT_IN_FOR_OMNIPOOL_BUY,
-					max_limit: 5 * ONE,
+					max_amount_in: 5 * ONE,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: DAI,
@@ -1501,7 +1501,7 @@ fn execution_fee_should_be_taken_from_user_in_sold_currency_in_case_of_successfu
 					asset_in: DAI,
 					asset_out: BTC,
 					amount_in,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: DAI,
@@ -1547,7 +1547,7 @@ fn sell_dca_native_execution_fee_should_be_taken_and_sent_to_treasury() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1591,7 +1591,7 @@ fn buy_dca_native_execution_fee_should_be_taken_and_sent_to_treasury() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: 10 * ONE,
-					max_limit: 10 * ONE,
+					max_amount_in: 10 * ONE,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1637,7 +1637,7 @@ fn slippage_limit_should_be_used_for_buy_dca_when_it_is_smaller_than_specified_t
 					asset_in: HDX,
 					asset_out: DAI,
 					amount_out: buy_amount,
-					max_limit: Balance::MAX,
+					max_amount_in: Balance::MAX,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1680,7 +1680,7 @@ fn one_sell_dca_execution_should_be_rescheduled_when_price_diff_is_more_than_max
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1743,7 +1743,7 @@ fn one_sell_dca_execution_should_be_rescheduled_when_price_diff_is_more_than_use
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1805,7 +1805,7 @@ fn one_buy_dca_execution_should_be_rescheduled_when_price_diff_is_more_than_max_
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: amount_to_buy,
-					max_limit,
+					max_amount_in: max_limit,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1853,7 +1853,7 @@ fn specified_slippage_should_be_used_in_circuit_breaker_price_check() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: amount_to_buy,
-					max_limit,
+					max_amount_in: max_limit,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1904,7 +1904,7 @@ fn dca_should_be_terminated_when_dca_cannot_be_planned_due_to_not_free_blocks() 
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -1957,7 +1957,7 @@ fn dca_should_be_terminated_when_price_change_is_big_but_no_free_blocks_to_repla
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -2002,7 +2002,7 @@ fn dca_should_be_executed_and_replanned_through_multiple_blocks_when_all_consque
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -2068,7 +2068,7 @@ fn dca_sell_schedule_should_be_completed_after_one_trade_when_total_amount_is_eq
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -2107,7 +2107,7 @@ fn dca_sell_schedule_should_be_terminated_when_schedule_allocation_is_more_than_
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in,
-					min_limit: 5 * ONE,
+					min_amount_out: 5 * ONE,
 					route: create_bounded_vec(vec![Trade {
 						pool: Omnipool,
 						asset_in: HDX,
@@ -2149,7 +2149,7 @@ fn schedules_are_purged_when_the_block_is_over() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -2203,7 +2203,7 @@ fn sell_schedule_should_be_completed_when_only_5_transaction_fee_left() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -2246,7 +2246,7 @@ fn sell_schedule_should_be_replanned_when_more_than_5_transaction_fee_left_for_n
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -2290,7 +2290,7 @@ fn execution_is_still_successfull_when_no_parent_hash_present() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: amount_to_sell,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,

--- a/pallets/dca/src/tests/schedule.rs
+++ b/pallets/dca/src/tests/schedule.rs
@@ -46,7 +46,6 @@ fn schedule_should_reserve_all_total_amount_as_named_reserve() {
 					asset_out: BTC,
 					amount_out: ONE,
 					max_limit: 10 * ONE,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -82,7 +81,6 @@ fn schedule_should_store_total_amounts_in_storage() {
 					asset_out: BTC,
 					amount_out: ONE,
 					max_limit: 10 * ONE,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -116,7 +114,6 @@ fn schedule_should_compound_named_reserve_for_multiple_schedules() {
 					asset_out: BTC,
 					amount_out: ONE,
 					max_limit: 100 * ONE,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -133,7 +130,6 @@ fn schedule_should_compound_named_reserve_for_multiple_schedules() {
 					asset_out: BTC,
 					amount_out: ONE,
 					max_limit: 1000 * ONE,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -373,7 +369,6 @@ fn sell_schedule_should_throw_error_when_total_budget_is_smaller_than_amount_to_
 					asset_out: BTC,
 					amount_in: budget + BUY_DCA_FEE_IN_NATIVE,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -410,7 +405,6 @@ fn buy_schedule_should_throw_error_when_total_budget_is_smaller_than_amount_in_p
 					asset_out: BTC,
 					amount_out: 10 * ONE,
 					max_limit: budget + BUY_DCA_FEE_IN_NATIVE,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -447,7 +441,6 @@ fn buy_schedule_should_work_when_total_budget_is_equal_to_calculated_amount_in_p
 					asset_out: BTC,
 					amount_out: 10 * ONE,
 					max_limit: budget + BUY_DCA_FEE_IN_NATIVE,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -608,7 +601,6 @@ fn schedule_should_fail_when_total_amount_is_smaller_than_min_budget_and_sold_cu
 					asset_out: BTC,
 					amount_out: ONE,
 					max_limit: 100 * ONE,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -642,7 +634,6 @@ fn schedule_should_fail_when_total_amount_in_non_native_currency_is_smaller_than
 					asset_out: HDX,
 					amount_out: ONE,
 					max_limit: 100 * ONE,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -676,7 +667,6 @@ fn schedule_should_fail_for_sell_when_sell_amount_is_smaller_than_fee() {
 					asset_out: BTC,
 					amount_in: SELL_DCA_FEE_IN_NATIVE - 1,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -707,7 +697,6 @@ fn schedule_should_fail_when_trade_amount_is_less_than_fee() {
 					asset_out: BTC,
 					amount_in: 50,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -742,7 +731,6 @@ fn sell_schedule_should_work_when_total_amount_is_equal_to_amount_in_plus_fee() 
 					asset_out: BTC,
 					amount_in,
 					min_limit: Balance::MIN,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -772,7 +760,6 @@ fn schedule_should_init_retries_to_zero() {
 					asset_out: BTC,
 					amount_out: ONE,
 					max_limit: 10 * ONE,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -807,7 +794,6 @@ fn schedule_should_fail_when_wrong_user_is_specified_in_schedule() {
 					asset_out: BTC,
 					amount_out: ONE,
 					max_limit: 10 * ONE,
-					slippage: None,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -842,7 +828,6 @@ fn schedule_should_fail_when_no_routes_specified() {
 					asset_out: BTC,
 					amount_out: ONE,
 					max_limit: 10 * ONE,
-					slippage: None,
 					route: create_bounded_vec(vec![]),
 				})
 				.build();

--- a/pallets/dca/src/tests/schedule.rs
+++ b/pallets/dca/src/tests/schedule.rs
@@ -45,7 +45,7 @@ fn schedule_should_reserve_all_total_amount_as_named_reserve() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: ONE,
-					max_limit: 10 * ONE,
+					max_amount_in: 10 * ONE,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -80,7 +80,7 @@ fn schedule_should_store_total_amounts_in_storage() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: ONE,
-					max_limit: 10 * ONE,
+					max_amount_in: 10 * ONE,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -113,7 +113,7 @@ fn schedule_should_compound_named_reserve_for_multiple_schedules() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: ONE,
-					max_limit: 100 * ONE,
+					max_amount_in: 100 * ONE,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -129,7 +129,7 @@ fn schedule_should_compound_named_reserve_for_multiple_schedules() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: ONE,
-					max_limit: 1000 * ONE,
+					max_amount_in: 1000 * ONE,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -368,7 +368,7 @@ fn sell_schedule_should_throw_error_when_total_budget_is_smaller_than_amount_to_
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: budget + BUY_DCA_FEE_IN_NATIVE,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -404,7 +404,7 @@ fn buy_schedule_should_throw_error_when_total_budget_is_smaller_than_amount_in_p
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: 10 * ONE,
-					max_limit: budget + BUY_DCA_FEE_IN_NATIVE,
+					max_amount_in: budget + BUY_DCA_FEE_IN_NATIVE,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -440,7 +440,7 @@ fn buy_schedule_should_work_when_total_budget_is_equal_to_calculated_amount_in_p
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: 10 * ONE,
-					max_limit: budget + BUY_DCA_FEE_IN_NATIVE,
+					max_amount_in: budget + BUY_DCA_FEE_IN_NATIVE,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -600,7 +600,7 @@ fn schedule_should_fail_when_total_amount_is_smaller_than_min_budget_and_sold_cu
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: ONE,
-					max_limit: 100 * ONE,
+					max_amount_in: 100 * ONE,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -633,7 +633,7 @@ fn schedule_should_fail_when_total_amount_in_non_native_currency_is_smaller_than
 					asset_in: DAI,
 					asset_out: HDX,
 					amount_out: ONE,
-					max_limit: 100 * ONE,
+					max_amount_in: 100 * ONE,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -666,7 +666,7 @@ fn schedule_should_fail_for_sell_when_sell_amount_is_smaller_than_fee() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: SELL_DCA_FEE_IN_NATIVE - 1,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -696,7 +696,7 @@ fn schedule_should_fail_when_trade_amount_is_less_than_fee() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in: 50,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -730,7 +730,7 @@ fn sell_schedule_should_work_when_total_amount_is_equal_to_amount_in_plus_fee() 
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_in,
-					min_limit: Balance::MIN,
+					min_amount_out: Balance::MIN,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -759,7 +759,7 @@ fn schedule_should_init_retries_to_zero() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: ONE,
-					max_limit: 10 * ONE,
+					max_amount_in: 10 * ONE,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -793,7 +793,7 @@ fn schedule_should_fail_when_wrong_user_is_specified_in_schedule() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: ONE,
-					max_limit: 10 * ONE,
+					max_amount_in: 10 * ONE,
 					route: create_bounded_vec(vec![Trade {
 						pool: PoolType::Omnipool,
 						asset_in: HDX,
@@ -827,7 +827,7 @@ fn schedule_should_fail_when_no_routes_specified() {
 					asset_in: HDX,
 					asset_out: BTC,
 					amount_out: ONE,
-					max_limit: 10 * ONE,
+					max_amount_in: 10 * ONE,
 					route: create_bounded_vec(vec![]),
 				})
 				.build();

--- a/pallets/dca/src/types.rs
+++ b/pallets/dca/src/types.rs
@@ -15,6 +15,7 @@ pub struct Schedule<AccountId, AssetId, BlockNumber> {
 	pub owner: AccountId,
 	pub period: BlockNumber,
 	pub total_amount: Balance,
+	pub max_retries: Option<u8>,
 	pub order: Order<AssetId>,
 }
 

--- a/pallets/dca/src/types.rs
+++ b/pallets/dca/src/types.rs
@@ -16,6 +16,7 @@ pub struct Schedule<AccountId, AssetId, BlockNumber> {
 	pub period: BlockNumber,
 	pub total_amount: Balance,
 	pub max_retries: Option<u8>,
+	pub stability_threshold: Option<Permill>,
 	pub order: Order<AssetId>,
 }
 

--- a/pallets/dca/src/types.rs
+++ b/pallets/dca/src/types.rs
@@ -27,14 +27,14 @@ pub enum Order<AssetId> {
 		asset_in: AssetId,
 		asset_out: AssetId,
 		amount_in: Balance,
-		min_limit: Balance,
+		min_amount_out: Balance,
 		route: BoundedVec<Trade<AssetId>, ConstU32<MAX_NUMBER_OF_TRADES>>,
 	},
 	Buy {
 		asset_in: AssetId,
 		asset_out: AssetId,
 		amount_out: Balance,
-		max_limit: Balance,
+		max_amount_in: Balance,
 		route: BoundedVec<Trade<AssetId>, ConstU32<MAX_NUMBER_OF_TRADES>>,
 	},
 }

--- a/pallets/dca/src/types.rs
+++ b/pallets/dca/src/types.rs
@@ -17,6 +17,7 @@ pub struct Schedule<AccountId, AssetId, BlockNumber> {
 	pub total_amount: Balance,
 	pub max_retries: Option<u8>,
 	pub stability_threshold: Option<Permill>,
+	pub slippage: Option<Permill>,
 	pub order: Order<AssetId>,
 }
 
@@ -27,7 +28,6 @@ pub enum Order<AssetId> {
 		asset_out: AssetId,
 		amount_in: Balance,
 		min_limit: Balance,
-		slippage: Option<Permill>,
 		route: BoundedVec<Trade<AssetId>, ConstU32<MAX_NUMBER_OF_TRADES>>,
 	},
 	Buy {
@@ -35,7 +35,6 @@ pub enum Order<AssetId> {
 		asset_out: AssetId,
 		amount_out: Balance,
 		max_limit: Balance,
-		slippage: Option<Permill>,
 		route: BoundedVec<Trade<AssetId>, ConstU32<MAX_NUMBER_OF_TRADES>>,
 	},
 }
@@ -58,14 +57,6 @@ where
 			Order::Buy { asset_out, .. } => asset_out,
 		};
 		*asset_out
-	}
-
-	pub fn get_slippage(&self) -> Option<Permill> {
-		let slippage = match &self {
-			Order::Sell { slippage, .. } => slippage,
-			Order::Buy { slippage, .. } => slippage,
-		};
-		*slippage
 	}
 
 	pub fn get_route_length(&self) -> usize {

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "157.0.0"
+version = "158.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -107,7 +107,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 157,
+	spec_version: 158,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/testing-hydradx/Cargo.toml
+++ b/runtime/testing-hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testing-hydradx-runtime"
-version = "157.0.0"
+version = "158.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/testing-hydradx/src/lib.rs
+++ b/runtime/testing-hydradx/src/lib.rs
@@ -114,7 +114,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("testing-hydradx"),
 	impl_name: create_runtime_str!("testing-hydradx"),
 	authoring_version: 1,
-	spec_version: 157,
+	spec_version: 158,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Changes:

- [x] make max number of retries configurable
- [x] make price stability threshold configurable
- [x] pull out slippage from order to Schedule as it is a generic parameter
- [x] rename order `min_limit` to `min_amount_out`
- [x] rename order `max_amount_in` to `max_amount_in`
- [x] fix edge case for sell: we replan a schedule only when the budget leftover is bigger than 5 * FEE
