### PR TITLE
fix: router ED leftover balance check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-route-executor"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10092,7 +10092,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.7.15"
+version = "1.7.16"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.7.15"
+version = "1.7.16"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/dca.rs
+++ b/integration-tests/src/dca.rs
@@ -1039,7 +1039,7 @@ fn sell_schedule_should_work_when_user_has_left_less_than_existential_deposit() 
 
 		//Assert
 		check_if_no_failed_events();
-		assert_balance!(ALICE.into(), HDX, alice_init_hdx_balance - dca_budget);
+		assert_balance!(ALICE.into(), HDX, 0);
 		assert_reserved_balance!(&ALICE.into(), HDX, 0);
 	});
 }

--- a/pallets/route-executor/Cargo.toml
+++ b/pallets/route-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-route-executor'
-version = '1.0.4'
+version = '1.0.5'
 description = 'A pallet to execute a route containing a sequence of trades'
 authors = ['GalacticCouncil']
 edition = '2021'

--- a/pallets/route-executor/src/lib.rs
+++ b/pallets/route-executor/src/lib.rs
@@ -336,12 +336,8 @@ impl<T: Config> Pallet<T> {
 	) -> Result<(), DispatchError> {
 		if spent_amount < user_balance_of_asset_in_before_trade {
 			let user_balance_of_asset_in_after_trade = T::Currency::reducible_balance(asset_in, &who, true);
-			let user_expected_balance_of_asset_in_after_trade = user_balance_of_asset_in_before_trade
-				.checked_sub(&spent_amount)
-				.ok_or(Error::<T>::UnexpectedError)?;
-
 			ensure!(
-				user_expected_balance_of_asset_in_after_trade == user_balance_of_asset_in_after_trade,
+				user_balance_of_asset_in_before_trade - spent_amount == user_balance_of_asset_in_after_trade,
 				Error::<T>::UnexpectedError
 			);
 		}

--- a/pallets/route-executor/src/lib.rs
+++ b/pallets/route-executor/src/lib.rs
@@ -246,7 +246,7 @@ pub mod pallet {
 			let who = ensure_signed(origin.clone())?;
 			Self::ensure_route_size(route.len())?;
 
-			let user_balance_of_asset_in_before_trade = T::Currency::reducible_balance(asset_in, &who, false);
+			let user_balance_of_asset_in_before_trade = T::Currency::reducible_balance(asset_in, &who, true);
 
 			let trade_amounts = Self::calculate_buy_trade_amounts(&route, amount_out)?;
 

--- a/pallets/route-executor/src/lib.rs
+++ b/pallets/route-executor/src/lib.rs
@@ -136,6 +136,8 @@ pub mod pallet {
 		RouteHasNoTrades,
 		///The user has not enough balance to execute the trade
 		InsufficientBalance,
+		///The balance after the trade is not as expected according to the trade amount
+		PostBalanceCheckError,
 		///Unexpected error which should never really happen, but the error case must be handled to prevent panics.
 		UnexpectedError,
 	}
@@ -322,7 +324,7 @@ impl<T: Config> Pallet<T> {
 
 		ensure!(
 			user_balance_of_asset_out_after_trade == user_expected_balance_of_asset_out_after_trade,
-			Error::<T>::UnexpectedError
+			Error::<T>::PostBalanceCheckError
 		);
 
 		Ok(())
@@ -338,7 +340,7 @@ impl<T: Config> Pallet<T> {
 			let user_balance_of_asset_in_after_trade = T::Currency::reducible_balance(asset_in, &who, true);
 			ensure!(
 				user_balance_of_asset_in_before_trade - spent_amount == user_balance_of_asset_in_after_trade,
-				Error::<T>::UnexpectedError
+				Error::<T>::PostBalanceCheckError
 			);
 		}
 		Ok(())

--- a/pallets/route-executor/src/lib.rs
+++ b/pallets/route-executor/src/lib.rs
@@ -183,7 +183,7 @@ pub mod pallet {
 			);
 
 			for (trade_amount, trade) in trade_amounts.iter().zip(route) {
-				let user_balance_of_asset_in_before_trade = T::Currency::reducible_balance(trade.asset_in, &who, false);
+				let user_balance_of_asset_in_before_trade = T::Currency::reducible_balance(trade.asset_in, &who, true);
 
 				let execution_result = T::AMM::execute_sell(
 					origin.clone(),
@@ -334,16 +334,17 @@ impl<T: Config> Pallet<T> {
 		user_balance_of_asset_in_before_trade: T::Balance,
 		spent_amount: T::Balance,
 	) -> Result<(), DispatchError> {
-		let user_balance_of_asset_in_after_trade = T::Currency::reducible_balance(asset_in, &who, false);
-		let user_expected_balance_of_asset_in_after_trade = user_balance_of_asset_in_before_trade
-			.checked_sub(&spent_amount)
-			.ok_or(Error::<T>::UnexpectedError)?;
+		if spent_amount < user_balance_of_asset_in_before_trade {
+			let user_balance_of_asset_in_after_trade = T::Currency::reducible_balance(asset_in, &who, true);
+			let user_expected_balance_of_asset_in_after_trade = user_balance_of_asset_in_before_trade
+				.checked_sub(&spent_amount)
+				.ok_or(Error::<T>::UnexpectedError)?;
 
-		ensure!(
-			user_expected_balance_of_asset_in_after_trade == user_balance_of_asset_in_after_trade,
-			Error::<T>::UnexpectedError
-		);
-
+			ensure!(
+				user_expected_balance_of_asset_in_after_trade == user_balance_of_asset_in_after_trade,
+				Error::<T>::UnexpectedError
+			);
+		}
 		Ok(())
 	}
 }


### PR DESCRIPTION
- [x] fix bug for the case when after a trade there is less than the existential deposit as user balance
- [x] use more descriptive errors instead of UnexpectedError