### PR TITLE
fix: stableswap asset order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "hydra-dx-math"
-version = "7.4.1"
+version = "7.4.2"
 dependencies = [
  "approx",
  "criterion",
@@ -7316,7 +7316,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-stableswap"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "bitflags",
  "frame-benchmarking",

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -6,7 +6,7 @@ license = 'Apache-2.0'
 name = "hydra-dx-math"
 description = "A collection of utilities to make performing liquidity pool calculations more convenient."
 repository = 'https://github.com/galacticcouncil/hydradx-math'
-version = "7.4.1"
+version = "7.4.2"
 
 [dependencies]
 primitive-types = {default-features = false, version = '0.12.0'}

--- a/math/src/stableswap/tests/multi_assets.rs
+++ b/math/src/stableswap/tests/multi_assets.rs
@@ -347,3 +347,111 @@ fn calculate_withdraw_should_return_correct_amount_when_removing_provided_shares
 
 	assert_eq!(result, (4993u128, 0u128));
 }
+
+#[test]
+fn calculate_out_given_in_with_fee_should_work_when_reserves_have_different_precision() {
+	let amp = 1000_u128;
+
+	let balances: [Balance; 3] = [1000_000_000, 3000_000_000, 5_000_000_000_000_000_000_000];
+
+	let result = calculate_out_given_in_with_fee::<D_ITERATIONS, Y_ITERATIONS>(
+		&balances,
+		1,
+		2,
+		1_000_000,
+		amp,
+		Permill::from_percent(1),
+	);
+	assert_eq!(result.unwrap(), (824_786_715_118_092_963, 8_331_178_940_586_797));
+
+	let result = calculate_out_given_in_with_fee::<D_ITERATIONS, Y_ITERATIONS>(
+		&balances,
+		2,
+		1,
+		1_000_000_000_000_000_000,
+		amp,
+		Permill::from_percent(1),
+	);
+	assert_eq!(result.unwrap(), (1_187_653, 11996));
+}
+
+#[test]
+fn calculate_out_given_in_with_zero_fee_should_work_when_reserves_have_different_precision() {
+	let amp = 1000_u128;
+
+	let balances: [Balance; 3] = [1000_000_000, 3000_000_000, 5_000_000_000_000_000_000_000];
+
+	let result = calculate_out_given_in_with_fee::<D_ITERATIONS, Y_ITERATIONS>(
+		&balances,
+		1,
+		2,
+		1_000_000,
+		amp,
+		Permill::from_percent(0),
+	);
+	assert_eq!(result.unwrap(), (824_786_715_118_092_963 + 8_331_178_940_586_797, 0));
+
+	let result = calculate_out_given_in_with_fee::<D_ITERATIONS, Y_ITERATIONS>(
+		&balances,
+		2,
+		1,
+		1_000_000_000_000_000_000,
+		amp,
+		Permill::from_percent(0),
+	);
+	assert_eq!(result.unwrap(), (1_187_653 + 11996, 0));
+}
+
+#[test]
+fn calculate_in_given_out_with_fee_should_work_when_reserves_have_different_precision() {
+	let amp = 1000_u128;
+
+	let balances: [Balance; 3] = [1000_000_000, 3000_000_000, 5_000_000_000_000_000_000_000];
+
+	let result = calculate_in_given_out_with_fee::<D_ITERATIONS, Y_ITERATIONS>(
+		&balances,
+		1,
+		2,
+		1_000_000_000_000_000_000,
+		amp,
+		Permill::from_percent(1),
+	);
+	assert_eq!(result.unwrap(), (1212376, 12004));
+
+	let result = calculate_in_given_out_with_fee::<D_ITERATIONS, Y_ITERATIONS>(
+		&balances,
+		2,
+		1,
+		1_000_000,
+		amp,
+		Permill::from_percent(1),
+	);
+	assert_eq!(result.unwrap(), (841869902748480839, 8335345571767138));
+}
+
+#[test]
+fn calculate_in_given_out_with_zero_fee_should_work_when_reserves_have_different_precision() {
+	let amp = 1000_u128;
+
+	let balances: [Balance; 3] = [1000_000_000, 3000_000_000, 5_000_000_000_000_000_000_000];
+
+	let result = calculate_in_given_out_with_fee::<D_ITERATIONS, Y_ITERATIONS>(
+		&balances,
+		1,
+		2,
+		1_000_000_000_000_000_000,
+		amp,
+		Permill::from_percent(0),
+	);
+	assert_eq!(result.unwrap(), (1212376 - 12004, 0));
+
+	let result = calculate_in_given_out_with_fee::<D_ITERATIONS, Y_ITERATIONS>(
+		&balances,
+		2,
+		1,
+		1_000_000,
+		amp,
+		Permill::from_percent(0),
+	);
+	assert_eq!(result.unwrap(), (841869902748480839 - 8335345571767138, 0));
+}

--- a/math/src/stableswap/tests/multi_assets.rs
+++ b/math/src/stableswap/tests/multi_assets.rs
@@ -352,7 +352,7 @@ fn calculate_withdraw_should_return_correct_amount_when_removing_provided_shares
 fn calculate_out_given_in_with_fee_should_work_when_reserves_have_different_precision() {
 	let amp = 1000_u128;
 
-	let balances: [Balance; 3] = [1000_000_000, 3000_000_000, 5_000_000_000_000_000_000_000];
+	let balances: [Balance; 3] = [1_000_000_000, 3_000_000_000, 5_000_000_000_000_000_000_000];
 
 	let result = calculate_out_given_in_with_fee::<D_ITERATIONS, Y_ITERATIONS>(
 		&balances,
@@ -379,7 +379,7 @@ fn calculate_out_given_in_with_fee_should_work_when_reserves_have_different_prec
 fn calculate_out_given_in_with_zero_fee_should_work_when_reserves_have_different_precision() {
 	let amp = 1000_u128;
 
-	let balances: [Balance; 3] = [1000_000_000, 3000_000_000, 5_000_000_000_000_000_000_000];
+	let balances: [Balance; 3] = [1_000_000_000, 3_000_000_000, 5_000_000_000_000_000_000_000];
 
 	let result = calculate_out_given_in_with_fee::<D_ITERATIONS, Y_ITERATIONS>(
 		&balances,
@@ -406,7 +406,7 @@ fn calculate_out_given_in_with_zero_fee_should_work_when_reserves_have_different
 fn calculate_in_given_out_with_fee_should_work_when_reserves_have_different_precision() {
 	let amp = 1000_u128;
 
-	let balances: [Balance; 3] = [1000_000_000, 3000_000_000, 5_000_000_000_000_000_000_000];
+	let balances: [Balance; 3] = [1_000_000_000, 3_000_000_000, 5_000_000_000_000_000_000_000];
 
 	let result = calculate_in_given_out_with_fee::<D_ITERATIONS, Y_ITERATIONS>(
 		&balances,
@@ -433,7 +433,7 @@ fn calculate_in_given_out_with_fee_should_work_when_reserves_have_different_prec
 fn calculate_in_given_out_with_zero_fee_should_work_when_reserves_have_different_precision() {
 	let amp = 1000_u128;
 
-	let balances: [Balance; 3] = [1000_000_000, 3000_000_000, 5_000_000_000_000_000_000_000];
+	let balances: [Balance; 3] = [1_000_000_000, 3_000_000_000, 5_000_000_000_000_000_000_000];
 
 	let result = calculate_in_given_out_with_fee::<D_ITERATIONS, Y_ITERATIONS>(
 		&balances,

--- a/pallets/stableswap/Cargo.toml
+++ b/pallets/stableswap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-stableswap'
-version = '2.1.0'
+version = '2.1.1'
 description = 'AMM for correlated assets'
 authors = ['GalacticCouncil']
 edition = '2021'

--- a/pallets/stableswap/src/lib.rs
+++ b/pallets/stableswap/src/lib.rs
@@ -631,7 +631,6 @@ pub mod pallet {
 			ensure!(amount_out >= min_buy_amount, Error::<T>::BuyLimitNotReached);
 
 			let pool_account = Self::pool_account(pool_id);
-
 			T::Currency::transfer(asset_in, &who, &pool_account, amount_in)?;
 			T::Currency::transfer(asset_out, &pool_account, &who, amount_out)?;
 
@@ -746,8 +745,8 @@ pub mod pallet {
 impl<T: Config> Pallet<T> {
 	fn calculate_out_amount(
 		pool_id: T::AssetId,
-		asset_out: T::AssetId,
 		asset_in: T::AssetId,
+		asset_out: T::AssetId,
 		amount_in: Balance,
 	) -> Result<(Balance, Balance), DispatchError> {
 		let pool = Pools::<T>::get(pool_id).ok_or(Error::<T>::PoolNotFound)?;

--- a/pallets/stableswap/src/tests/trades.rs
+++ b/pallets/stableswap/src/tests/trades.rs
@@ -514,7 +514,7 @@ fn sell_should_work_when_pool_have_asset_with_various_decimals() {
 		.with_registered_asset("two".as_bytes().to_vec(), 2)
 		.with_registered_asset("three".as_bytes().to_vec(), 3)
 		.with_endowed_accounts(vec![
-			(BOB, asset_c, 1 * ONE * 1_000_000),
+			(BOB, asset_c, ONE * 1_000_000),
 			(ALICE, asset_a, 2000 * ONE),
 			(ALICE, asset_b, 4000 * ONE),
 			(ALICE, asset_c, 10000 * ONE * 1_000_000),
@@ -535,11 +535,11 @@ fn sell_should_work_when_pool_have_asset_with_various_decimals() {
 				assets: vec![
 					AssetBalance {
 						asset_id: asset_a,
-						amount: 1000_000_000,
+						amount: 1_000_000_000,
 					},
 					AssetBalance {
 						asset_id: asset_b,
-						amount: 3000_000_000,
+						amount: 3_000_000_000,
 					},
 					AssetBalance {
 						asset_id: asset_c,
@@ -557,7 +557,7 @@ fn sell_should_work_when_pool_have_asset_with_various_decimals() {
 				pool_id,
 				asset_c,
 				asset_b,
-				1 * ONE * 1_000_000,
+				ONE * 1_000_000,
 				0,
 			));
 
@@ -567,8 +567,8 @@ fn sell_should_work_when_pool_have_asset_with_various_decimals() {
 
 			assert_balance!(BOB, asset_c, 0);
 			assert_balance!(BOB, asset_b, expected);
-			assert_balance!(pool_account, asset_c, 5001_000_000_000_000_000_000);
-			assert_balance!(pool_account, asset_b, 3000_000_000 - expected);
+			assert_balance!(pool_account, asset_c, 5_001_000_000_000_000_000_000);
+			assert_balance!(pool_account, asset_b, 3_000_000_000 - expected);
 		});
 }
 
@@ -583,7 +583,7 @@ fn buy_should_work_when_pool_have_asset_with_various_decimals() {
 		.with_registered_asset("two".as_bytes().to_vec(), 2)
 		.with_registered_asset("three".as_bytes().to_vec(), 3)
 		.with_endowed_accounts(vec![
-			(BOB, asset_c, 1 * ONE * 1_000_000),
+			(BOB, asset_c, ONE * 1_000_000),
 			(ALICE, asset_a, 2000 * ONE),
 			(ALICE, asset_b, 4000 * ONE),
 			(ALICE, asset_c, 10000 * ONE * 1_000_000),
@@ -604,11 +604,11 @@ fn buy_should_work_when_pool_have_asset_with_various_decimals() {
 				assets: vec![
 					AssetBalance {
 						asset_id: asset_a,
-						amount: 1000_000_000,
+						amount: 1_000_000_000,
 					},
 					AssetBalance {
 						asset_id: asset_b,
-						amount: 3000_000_000,
+						amount: 3_000_000_000,
 					},
 					AssetBalance {
 						asset_id: asset_c,
@@ -637,6 +637,6 @@ fn buy_should_work_when_pool_have_asset_with_various_decimals() {
 			assert_balance!(BOB, asset_c, 1_174_293_340_450);
 			assert_balance!(BOB, asset_b, expected);
 			assert_balance!(pool_account, asset_c, 5000999998825706659550);
-			assert_balance!(pool_account, asset_b, 3000_000_000 - expected);
+			assert_balance!(pool_account, asset_b, 3_000_000_000 - expected);
 		});
 }

--- a/pallets/stableswap/src/tests/trades.rs
+++ b/pallets/stableswap/src/tests/trades.rs
@@ -502,3 +502,141 @@ fn buy_should_fail_when_insufficient_amount_is_provided() {
 			);
 		});
 }
+
+#[test]
+fn sell_should_work_when_pool_have_asset_with_various_decimals() {
+	let asset_a: AssetId = 1;
+	let asset_b: AssetId = 2;
+	let asset_c: AssetId = 3;
+	ExtBuilder::default()
+		.with_endowed_accounts(vec![(BOB, 1, 200 * ONE), (ALICE, 1, 200 * ONE), (ALICE, 2, 200 * ONE)])
+		.with_registered_asset("one".as_bytes().to_vec(), 1)
+		.with_registered_asset("two".as_bytes().to_vec(), 2)
+		.with_registered_asset("three".as_bytes().to_vec(), 3)
+		.with_endowed_accounts(vec![
+			(BOB, asset_c, 1 * ONE * 1_000_000),
+			(ALICE, asset_a, 2000 * ONE),
+			(ALICE, asset_b, 4000 * ONE),
+			(ALICE, asset_c, 10000 * ONE * 1_000_000),
+		])
+		.with_pool(
+			ALICE,
+			PoolInfo::<AssetId, u64> {
+				assets: vec![asset_a, asset_b, asset_c].try_into().unwrap(),
+				initial_amplification: NonZeroU16::new(1000).unwrap(),
+				final_amplification: NonZeroU16::new(1000).unwrap(),
+				initial_block: 0,
+				trade_fee: Permill::from_percent(0),
+				withdraw_fee: Permill::from_percent(0),
+				final_block: 0,
+			},
+			InitialLiquidity {
+				account: ALICE,
+				assets: vec![
+					AssetBalance {
+						asset_id: asset_a,
+						amount: 1000_000_000,
+					},
+					AssetBalance {
+						asset_id: asset_b,
+						amount: 3000_000_000,
+					},
+					AssetBalance {
+						asset_id: asset_c,
+						amount: 5000 * ONE * 1_000_000,
+					},
+				],
+			},
+		)
+		.build()
+		.execute_with(|| {
+			let pool_id = get_pool_id_at(0);
+
+			assert_ok!(Stableswap::sell(
+				RuntimeOrigin::signed(BOB),
+				pool_id,
+				asset_c,
+				asset_b,
+				1 * ONE * 1_000_000,
+				0,
+			));
+
+			let expected = 1_199_649;
+
+			let pool_account = pool_account(pool_id);
+
+			assert_balance!(BOB, asset_c, 0);
+			assert_balance!(BOB, asset_b, expected);
+			assert_balance!(pool_account, asset_c, 5001_000_000_000_000_000_000);
+			assert_balance!(pool_account, asset_b, 3000_000_000 - expected);
+		});
+}
+
+#[test]
+fn buy_should_work_when_pool_have_asset_with_various_decimals() {
+	let asset_a: AssetId = 1;
+	let asset_b: AssetId = 2;
+	let asset_c: AssetId = 3;
+	ExtBuilder::default()
+		.with_endowed_accounts(vec![(BOB, 1, 200 * ONE), (ALICE, 1, 200 * ONE), (ALICE, 2, 200 * ONE)])
+		.with_registered_asset("one".as_bytes().to_vec(), 1)
+		.with_registered_asset("two".as_bytes().to_vec(), 2)
+		.with_registered_asset("three".as_bytes().to_vec(), 3)
+		.with_endowed_accounts(vec![
+			(BOB, asset_c, 1 * ONE * 1_000_000),
+			(ALICE, asset_a, 2000 * ONE),
+			(ALICE, asset_b, 4000 * ONE),
+			(ALICE, asset_c, 10000 * ONE * 1_000_000),
+		])
+		.with_pool(
+			ALICE,
+			PoolInfo::<AssetId, u64> {
+				assets: vec![asset_a, asset_b, asset_c].try_into().unwrap(),
+				initial_amplification: NonZeroU16::new(1000).unwrap(),
+				final_amplification: NonZeroU16::new(1000).unwrap(),
+				initial_block: 0,
+				trade_fee: Permill::from_percent(0),
+				withdraw_fee: Permill::from_percent(0),
+				final_block: 0,
+			},
+			InitialLiquidity {
+				account: ALICE,
+				assets: vec![
+					AssetBalance {
+						asset_id: asset_a,
+						amount: 1000_000_000,
+					},
+					AssetBalance {
+						asset_id: asset_b,
+						amount: 3000_000_000,
+					},
+					AssetBalance {
+						asset_id: asset_c,
+						amount: 5000 * ONE * 1_000_000,
+					},
+				],
+			},
+		)
+		.build()
+		.execute_with(|| {
+			let pool_id = get_pool_id_at(0);
+
+			assert_ok!(Stableswap::buy(
+				RuntimeOrigin::signed(BOB),
+				pool_id,
+				asset_b,
+				asset_c,
+				1_199_649,
+				2 * ONE * 1_000_000,
+			));
+
+			let expected = 1_199_649;
+
+			let pool_account = pool_account(pool_id);
+
+			assert_balance!(BOB, asset_c, 1_174_293_340_450);
+			assert_balance!(BOB, asset_b, expected);
+			assert_balance!(pool_account, asset_c, 5000999998825706659550);
+			assert_balance!(pool_account, asset_b, 3000_000_000 - expected);
+		});
+}


### PR DESCRIPTION
There is a little bug in sell functionality where the order are flipped as input to calculate_out_amount function. 

This works ok (ish) for pools where assets have all the same decimals but becomes more obvious where there is one with different number of decimals. Hence spotted quite late.