### PR TITLE
feat: collator rewards bounded storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3815,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "167.0.0"
+version = "168.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -6462,7 +6462,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-collator-rewards"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/pallets/collator-rewards/Cargo.toml
+++ b/pallets/collator-rewards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-collator-rewards"
-version = "1.0.4"
+version = "1.0.5"
 description = "Pallet for collator rewards"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/collator-rewards/src/migration.rs
+++ b/pallets/collator-rewards/src/migration.rs
@@ -1,0 +1,78 @@
+// This file is part of pallet-collator-rewards
+
+// Copyright (C) 2020-2023  Intergalactic, Limited (GIB).
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License..
+
+use super::*;
+use frame_support::{
+	log, storage_alias,
+	traits::{Get, StorageVersion},
+	weights::Weight,
+};
+
+/// The log target.
+const TARGET: &str = "runtime::collator-rewards::migration::v1";
+
+pub mod v0 {
+	use super::*;
+	use frame_support::{pallet_prelude::ValueQuery, Twox64Concat};
+
+	#[storage_alias]
+	pub type Collators<T: Config> =
+		StorageMap<Pallet<T>, Twox64Concat, SessionIndex, Vec<<T as frame_system::Config>::AccountId>, ValueQuery>;
+}
+pub mod v1 {
+	use super::*;
+
+	pub fn pre_migrate<T: Config>() {
+		assert_eq!(StorageVersion::get::<Pallet<T>>(), 0, "Storage version too high.");
+
+		log::info!(target: TARGET, "Collator rewards migration: PRE checks successful!");
+	}
+
+	pub fn migrate<T: Config>() -> Weight {
+		log::info!(target: TARGET, "Collator rewards to v1 for Transaction pause");
+
+		let mut weight = Weight::zero();
+
+		Collators::<T>::translate::<Vec<<T as frame_system::Config>::AccountId>, _>(|session_index, old_value| {
+			let maybe_collators_b =
+				BoundedVec::<<T as frame_system::Config>::AccountId, T::MaxCandidates>::try_from(old_value.clone());
+			match maybe_collators_b {
+				Ok(collators_b) => {
+					weight.saturating_accrue(T::DbWeight::get().writes(1));
+					Some(collators_b)
+				}
+				Err(_) => {
+					log::info!(
+						target: TARGET,
+						"Value not migrated because it's too long: {:?}",
+						(session_index, old_value)
+					);
+					None
+				}
+			}
+		});
+
+		StorageVersion::new(1).put::<Pallet<T>>();
+		weight.saturating_add(T::DbWeight::get().writes(1))
+	}
+
+	pub fn post_migrate<T: Config>() {
+		assert_eq!(StorageVersion::get::<Pallet<T>>(), 1, "Unexpected storage version.");
+
+		log::info!(target: TARGET, "Collator rewards migration: POST checks successful!");
+	}
+}

--- a/pallets/collator-rewards/src/mock.rs
+++ b/pallets/collator-rewards/src/mock.rs
@@ -121,14 +121,10 @@ impl pallet_balances::Config for Test {
 }
 
 parameter_types! {
-	pub const Offset: u64 = 0;
-	pub const Period: u64 = 10;
-}
-
-parameter_types! {
 	pub const RewardPerCollator: Balance = COLLATOR_REWARD;
 	pub const RewardCurrencyId: AssetId = NATIVE_TOKEN;
 	pub GcCollators: Vec<AccountId> = vec![GC_COLL_1, GC_COLL_2, GC_COLL_3];
+	pub const MaxCandidates: u32 = 50;
 }
 
 thread_local! {
@@ -155,6 +151,7 @@ impl Config for Test {
 	type RewardCurrencyId = RewardCurrencyId;
 	type ExcludedCollators = GcCollators;
 	type SessionManager = MockSessionManager;
+	type MaxCandidates = MaxCandidates;
 }
 
 #[derive(Default)]

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "167.0.0"
+version = "168.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -95,7 +95,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 167,
+	spec_version: 168,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -232,17 +232,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsReversedWithSystemFirst,
-	(
-		pallet_preimage::migration::v1::Migration<Runtime>,
-		pallet_democracy::migrations::v1::Migration<Runtime>,
-		pallet_multisig::migrations::v1::MigrateToV1<Runtime>,
-		DmpQueue,
-		XcmpQueue,
-		ParachainSystem,
-		migrations::OnRuntimeUpgradeMigration,
-		migrations::MigrateRegistryLocationToV3<Runtime>,
-		migrations::XcmRateLimitMigration,
-	),
+	(migrations::OnRuntimeUpgradeMigration,),
 >;
 
 impl_runtime_apis! {

--- a/runtime/hydradx/src/migrations.rs
+++ b/runtime/hydradx/src/migrations.rs
@@ -11,9 +11,9 @@ pub struct OnRuntimeUpgradeMigration;
 impl OnRuntimeUpgrade for OnRuntimeUpgradeMigration {
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
-		frame_support::log::info!("PreMigrate Duster Pallet start");
-		pallet_duster::migration::v1::pre_migrate::<Runtime, Duster>();
-		frame_support::log::info!("PreMigrate Duster Pallet end");
+		log::info!("PreMigrate Collator Rewards Pallet start");
+		pallet_collator_rewards::migration::v1::pre_migrate::<Runtime>();
+		log::info!("PreMigrate Collator Rewards Pallet end");
 
 		Ok(vec![])
 	}
@@ -21,26 +21,18 @@ impl OnRuntimeUpgrade for OnRuntimeUpgradeMigration {
 	fn on_runtime_upgrade() -> Weight {
 		let mut weight: Weight = Weight::zero();
 
-		frame_support::log::info!("Migrate Scheduler Pallet to v4 start");
-		weight = weight.saturating_add(Scheduler::migrate_v1_to_v4());
-		frame_support::log::info!("Migrate Scheduler Pallet to v4 end");
-
-		frame_support::log::info!("Migrate Duster Pallet to v1 start");
-		weight = weight.saturating_add(pallet_duster::migration::v1::migrate::<Runtime, Duster>(
-			get_all_module_accounts(),
-			TreasuryAccount::get(),
-			TreasuryAccount::get(),
-		));
-		frame_support::log::info!("Migrate Duster Pallet to v1 end");
+		log::info!("Migrate Collator Rewards Pallet to v1 start");
+		weight = weight.saturating_add(pallet_collator_rewards::migration::v1::migrate::<Runtime>());
+		log::info!("Migrate Collator Rewards Pallet to v1 end");
 
 		weight
 	}
 
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade(_state: Vec<u8>) -> Result<(), &'static str> {
-		frame_support::log::info!("PostMigrate Duster Pallet start");
-		pallet_duster::migration::v1::post_migrate::<Runtime, Duster>();
-		frame_support::log::info!("PostMigrate Duster Pallet end");
+		log::info!("PostMigrate Collator Rewards Pallet start");
+		pallet_collator_rewards::migration::v1::post_migrate::<Runtime>();
+		log::info!("PostMigrate Collator Rewards Pallet end");
 		Ok(())
 	}
 }

--- a/runtime/hydradx/src/system.rs
+++ b/runtime/hydradx/src/system.rs
@@ -501,9 +501,10 @@ impl pallet_collator_rewards::Config for Runtime {
 	type RewardPerCollator = RewardPerCollator;
 	type RewardCurrencyId = NativeAssetId;
 	type ExcludedCollators = ExcludedCollators;
-	// We wrap the ` SessionManager` implementation of `CollatorSelection` to get the collatrs that
+	// We wrap the ` SessionManager` implementation of `CollatorSelection` to get the collators that
 	// we hand out rewards to.
 	type SessionManager = CollatorSelection;
+	type MaxCandidates = MaxInvulnerables;
 }
 
 impl pallet_transaction_pause::Config for Runtime {


### PR DESCRIPTION
This PR removes `without_storage_info` from the Collator rewards pallet and adds a storage migration.