### PR TITLE
feat: enable polkadotXcm.send

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3814,7 +3814,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "169.0.0"
+version = "170.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10072,7 +10072,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.8.1"
+version = "1.8.2"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/call_filter.rs
+++ b/integration-tests/src/call_filter.rs
@@ -5,6 +5,7 @@ use frame_support::{
 	assert_ok,
 	sp_runtime::{FixedU128, Permill},
 	traits::Contains,
+	weights::Weight,
 };
 use polkadot_xcm::latest::prelude::*;
 use polkadot_xcm::VersionedXcm;
@@ -206,7 +207,7 @@ fn transfer_should_not_work_when_transfering_omnipool_assets_to_omnipool_account
 }
 
 #[test]
-fn calling_pallet_xcm_extrinsic_should_be_filtered_by_call_filter() {
+fn calling_pallet_xcm_send_extrinsic_should_not_be_filtered_by_call_filter() {
 	TestNet::reset();
 
 	Hydra::execute_with(|| {
@@ -214,6 +215,21 @@ fn calling_pallet_xcm_extrinsic_should_be_filtered_by_call_filter() {
 		let call = hydradx_runtime::RuntimeCall::PolkadotXcm(pallet_xcm::Call::send {
 			dest: Box::new(MultiLocation::parent().into()),
 			message: Box::new(VersionedXcm::from(Xcm(vec![]))),
+		});
+
+		assert!(hydradx_runtime::CallFilter::contains(&call));
+	});
+}
+
+#[test]
+fn calling_pallet_xcm_extrinsic_should_be_filtered_by_call_filter() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		// the values here don't need to make sense, all we need is a valid Call
+		let call = hydradx_runtime::RuntimeCall::PolkadotXcm(pallet_xcm::Call::execute {
+			message: Box::new(VersionedXcm::from(Xcm(vec![]))),
+			max_weight: Weight::zero(),
 		});
 
 		assert!(!hydradx_runtime::CallFilter::contains(&call));

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "169.0.0"
+version = "170.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -95,7 +95,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 169,
+	spec_version: 170,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/hydradx/src/system.rs
+++ b/runtime/hydradx/src/system.rs
@@ -84,6 +84,7 @@ impl Contains<RuntimeCall> for CallFilter {
 		}
 
 		match call {
+			RuntimeCall::PolkadotXcm(pallet_xcm::Call::send { .. }) => true,
 			RuntimeCall::PolkadotXcm(_) => false,
 			RuntimeCall::OrmlXcm(_) => false,
 			_ => true,

--- a/runtime/hydradx/src/xcm.rs
+++ b/runtime/hydradx/src/xcm.rs
@@ -413,7 +413,6 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 				| RuntimeCall::Currencies(..)
 				| RuntimeCall::Tokens(..)
 				| RuntimeCall::OrmlXcm(..)
-				| RuntimeCall::PolkadotXcm(pallet_xcm::Call::send { .. },)
 		)
 	}
 }

--- a/runtime/hydradx/src/xcm.rs
+++ b/runtime/hydradx/src/xcm.rs
@@ -413,6 +413,7 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 				| RuntimeCall::Currencies(..)
 				| RuntimeCall::Tokens(..)
 				| RuntimeCall::OrmlXcm(..)
+				| RuntimeCall::PolkadotXcm(pallet_xcm::Call::send { .. },)
 		)
 	}
 }


### PR DESCRIPTION
Allow polkadotXcm.send to be called locally as an extrinsic and remotely within a XCM Transact call