### PR TITLE
feat: add generic create registry asset which accepts asset type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-traits"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -6196,7 +6196,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-registry"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/pallets/asset-registry/Cargo.toml
+++ b/pallets/asset-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-asset-registry"
-version = "2.2.3"
+version = "2.2.4"
 description = "Pallet for asset registry management"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/asset-registry/src/lib.rs
+++ b/pallets/asset-registry/src/lib.rs
@@ -46,7 +46,7 @@ pub use pallet::*;
 
 use crate::types::{AssetDetails, AssetMetadata};
 use frame_support::BoundedVec;
-use hydradx_traits::{Registry, ShareTokenRegistry};
+use hydradx_traits::{AssetKind, CreateRegistry, Registry, ShareTokenRegistry};
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -612,5 +612,14 @@ pub struct XcmRateLimitsInRegistry<T>(PhantomData<T>);
 impl<T: Config> GetByKey<T::AssetId, Option<T::Balance>> for XcmRateLimitsInRegistry<T> {
 	fn get(k: &T::AssetId) -> Option<T::Balance> {
 		Pallet::<T>::assets(k).and_then(|details| details.xcm_rate_limit)
+	}
+}
+
+impl<T: Config> CreateRegistry<T::AssetId, T::Balance> for Pallet<T> {
+	type Error = DispatchError;
+
+	fn create_asset(name: &[u8], kind: AssetKind, existential_deposit: T::Balance) -> Result<T::AssetId, Self::Error> {
+		let bounded_name: BoundedVec<u8, T::StringLimit> = Self::to_bounded_name(name.to_vec())?;
+		Pallet::<T>::register_asset(bounded_name, kind.into(), existential_deposit, None, None)
 	}
 }

--- a/pallets/asset-registry/src/types.rs
+++ b/pallets/asset-registry/src/types.rs
@@ -27,7 +27,6 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum AssetType<AssetId> {
 	Token,
-	#[deprecated(note = "Use XYK")]
 	PoolShare(AssetId, AssetId),
 	XYK,
 	StableSwap,

--- a/pallets/asset-registry/src/types.rs
+++ b/pallets/asset-registry/src/types.rs
@@ -19,6 +19,7 @@ use frame_support::pallet_prelude::*;
 use scale_info::TypeInfo;
 use sp_std::vec::Vec;
 
+use hydradx_traits::AssetKind;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 
@@ -26,8 +27,22 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum AssetType<AssetId> {
 	Token,
+	#[deprecated(note = "Use XYK")]
 	PoolShare(AssetId, AssetId),
+	XYK,
 	StableSwap,
+	Bond,
+}
+
+impl<AssetId> From<AssetKind> for AssetType<AssetId> {
+	fn from(value: AssetKind) -> Self {
+		match value {
+			AssetKind::Token => Self::Token,
+			AssetKind::XYK => Self::XYK,
+			AssetKind::StableSwap => Self::StableSwap,
+			AssetKind::Bond => Self::Bond,
+		}
+	}
 }
 
 #[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]

--- a/pallets/asset-registry/src/types.rs
+++ b/pallets/asset-registry/src/types.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum AssetType<AssetId> {
 	Token,
-	PoolShare(AssetId, AssetId),
+	PoolShare(AssetId, AssetId), // Use XYX instead
 	XYK,
 	StableSwap,
 	Bond,

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-traits"
-version = "2.4.0"
+version = "2.5.0"
 description = "Shared traits"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/traits/src/registry.rs
+++ b/traits/src/registry.rs
@@ -16,6 +16,7 @@ pub trait Registry<AssetId, AssetName, Balance, Error> {
 	}
 }
 
+#[deprecated(note = "Use CreateRegistry instead")]
 pub trait ShareTokenRegistry<AssetId, AssetName, Balance, Error>: Registry<AssetId, AssetName, Balance, Error> {
 	fn retrieve_shared_asset(name: &AssetName, assets: &[AssetId]) -> Result<AssetId, Error>;
 
@@ -36,6 +37,19 @@ pub trait ShareTokenRegistry<AssetId, AssetName, Balance, Error>: Registry<Asset
 			Self::create_shared_asset(&name, &assets, existential_deposit)
 		}
 	}
+}
+
+#[derive(Eq, PartialEq, Copy, Clone)]
+pub enum AssetKind {
+	Token,
+	XYK,
+	StableSwap,
+	Bond,
+}
+
+pub trait CreateRegistry<AssetId, Balance> {
+	type Error;
+	fn create_asset(name: &[u8], kind: AssetKind, existential_deposit: Balance) -> Result<AssetId, Self::Error>;
 }
 
 // Deprecated.

--- a/traits/src/registry.rs
+++ b/traits/src/registry.rs
@@ -16,7 +16,7 @@ pub trait Registry<AssetId, AssetName, Balance, Error> {
 	}
 }
 
-#[deprecated(note = "Use CreateRegistry instead")]
+// Use CreateRegistry if possible
 pub trait ShareTokenRegistry<AssetId, AssetName, Balance, Error>: Registry<AssetId, AssetName, Balance, Error> {
 	fn retrieve_shared_asset(name: &AssetName, assets: &[AssetId]) -> Result<AssetId, Error>;
 


### PR DESCRIPTION
This PR refactors registry trait for asset creation. Previously it was not possible to specify asset type as parameter, so there was not a way to create other assets than share PoolAsset type. 

With new types, Stableswap and Bond, it is required to register such type trhough some kind of generic interface.

Hence, the new CreateRegistry trait. 