### PR TITLE
fix: calculates action points based on percentage of stake used in votings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3797,7 +3797,7 @@ dependencies = [
  "pallet-omnipool",
  "pallet-omnipool-liquidity-mining",
  "pallet-route-executor",
- "pallet-staking 1.0.0",
+ "pallet-staking 1.0.1",
  "pallet-transaction-multi-payment",
  "pallet-uniques",
  "parity-scale-codec",
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "174.0.0"
+version = "17.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -3878,7 +3878,7 @@ dependencies = [
  "pallet-route-executor",
  "pallet-scheduler",
  "pallet-session",
- "pallet-staking 1.0.0",
+ "pallet-staking 1.0.1",
  "pallet-timestamp",
  "pallet-tips",
  "pallet-transaction-multi-payment",
@@ -7393,7 +7393,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10227,7 +10227,7 @@ dependencies = [
  "pallet-route-executor",
  "pallet-scheduler",
  "pallet-session",
- "pallet-staking 1.0.0",
+ "pallet-staking 1.0.1",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-tips",

--- a/integration-tests/src/staking.rs
+++ b/integration-tests/src/staking.rs
@@ -208,7 +208,7 @@ fn staking_action_should_claim_points_for_finished_referendums_when_voted() {
 		let stake_position =
 			pallet_staking::Pallet::<hydradx_runtime::Runtime>::get_position(alice_position_id).unwrap();
 
-		assert_eq!(stake_position.get_action_points(), 100);
+		assert_eq!(stake_position.get_action_points(), 1);
 		assert!(stake_voting.votes.is_empty());
 	});
 }
@@ -274,7 +274,7 @@ fn staking_should_transfer_rewards_when_claimed() {
 		let stake_position =
 			pallet_staking::Pallet::<hydradx_runtime::Runtime>::get_position(alice_position_id).unwrap();
 
-		assert_eq!(stake_position.get_action_points(), 100);
+		assert_eq!(stake_position.get_action_points(), 1);
 		assert!(stake_voting.votes.is_empty());
 	});
 }

--- a/pallets/staking/Cargo.toml
+++ b/pallets/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-staking"
-version = "1.0.0"
+version = "1.0.1"
 authors = ['GalacticCouncil']
 edition = "2021"
 license = "Apache-2.0"

--- a/pallets/staking/src/tests/mock.rs
+++ b/pallets/staking/src/tests/mock.rs
@@ -220,20 +220,19 @@ impl pallet_staking::Config for Test {
 
 	type PayablePercentage = SigmoidPercentage<PointPercentage, ConstU32<40_000>>;
 	type MaxVotes = MaxVotes;
-	type ActionMultiplier = DummyActionMultiplier;
+	type MaxPointsPerAction = DummyMaxPointsPerAction;
 	type ReferendumInfo = DummyReferendumStatus;
 	type Vesting = DummyVesting;
 	type Collections = FreezableUniques;
 	type AuthorityOrigin = EnsureRoot<AccountId>;
-	type RewardedVoteUnit = ConstU128<ONE>;
 }
 
-pub struct DummyActionMultiplier;
+pub struct DummyMaxPointsPerAction;
 
-impl GetByKey<Action, u32> for DummyActionMultiplier {
+impl GetByKey<Action, u32> for DummyMaxPointsPerAction {
 	fn get(k: &Action) -> u32 {
 		match k {
-			Action::DemocracyVote => 1_u32,
+			Action::DemocracyVote => 100_u32,
 		}
 	}
 }

--- a/pallets/staking/src/tests/unstake.rs
+++ b/pallets/staking/src/tests/unstake.rs
@@ -472,7 +472,7 @@ fn unstake_should_clear_votes_when_staking_position_exists() {
 			assert_ok!(Staking::unstake(RuntimeOrigin::signed(BOB), bob_position_id));
 
 			//Assert
-			assert_unlocked_balance!(&BOB, HDX, 260_671_709_925_645_495_u128);
+			assert_unlocked_balance!(&BOB, HDX, 250_903_890_918_838_024_u128);
 			assert_hdx_lock!(BOB, 0, STAKING_LOCK);
 			assert_eq!(Staking::positions(bob_position_id), None);
 

--- a/pallets/staking/src/types.rs
+++ b/pallets/staking/src/types.rs
@@ -102,6 +102,10 @@ impl Conviction {
 			Conviction::Locked6x => FixedU128::from(6_u128),
 		}
 	}
+
+	pub fn max_multiplier() -> FixedU128 {
+		Conviction::Locked6x.multiplier()
+	}
 }
 
 #[derive(Encode, Decode, Copy, Clone, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "174.0.0"
+version = "17.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/assets.rs
+++ b/runtime/hydradx/src/assets.rs
@@ -525,15 +525,14 @@ parameter_types! {
 	pub const CurrentStakeWeight: u8 = 2;
 	pub const UnclaimablePeriods: BlockNumber = 1;
 	pub const PointPercentage: FixedU128 = FixedU128::from_rational(2,100);
-	pub const OneHDX: Balance = primitives::constants::currency::UNITS;
 }
 
-pub struct ActionMultiplier;
+pub struct PointsPerAction;
 
-impl GetByKey<Action, u32> for ActionMultiplier {
+impl GetByKey<Action, u32> for PointsPerAction {
 	fn get(k: &Action) -> u32 {
 		match k {
-			Action::DemocracyVote => 1u32,
+			Action::DemocracyVote => 100_u32,
 		}
 	}
 }
@@ -561,9 +560,8 @@ impl pallet_staking::Config for Runtime {
 	type NFTHandler = Uniques;
 	type MaxVotes = MaxVotes;
 	type ReferendumInfo = pallet_staking::integrations::democracy::ReferendumStatus<Runtime>;
-	type ActionMultiplier = ActionMultiplier;
+	type MaxPointsPerAction = PointsPerAction;
 	type Vesting = VestingInfo<Runtime>;
-	type RewardedVoteUnit = OneHDX;
 	type WeightInfo = weights::staking::HydraWeight<Runtime>;
 }
 

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -94,7 +94,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 174,
+	spec_version: 175,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Issue:
Current staking calculates action points based on the amount and conviction used in votes which can result in the situation where users with bigger stake accumulates action points quicker than users with smaller stake.
Fix:
We introduced constant amount of action points per each referenda and users receives portion of this point based on percentage of tokens used in voting from their max stake.
e.g.
max points per referenda = 100, 
user's A stake =  1000 HDX, user's B stake = 500HDX
case1:
 user's A vote with 500HDX and max conviction = 50 action points
 user's B vote with 250HDX and max conviction = 50 action points
case2:
 user's A vote with 1000HDX and max conviction = 100 action points
 user's B vote with 500HDX and max conviction = 100 action points
