### PR TITLE
chore: update Docker image from Ubuntu 21.04 to Ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 LABEL org.opencontainers.image.source = "https://github.com/galacticcouncil/HydraDX-node"
 
 RUN useradd -m -u 1000 -U -s /bin/sh -d /hydra hydra && \


### PR DESCRIPTION
It related to ISSUE-665 https://github.com/galacticcouncil/HydraDX-node/issues/665

Another solution which should be better, but it also would cause the compiling phase running for hours. I guess it will introduce a side effect to your working process.

```
FROM rust:1.67 as builder

RUN \
    --mount=type=cache,target=/var/cache/apt \
	apt update && \
	apt dist-upgrade -y && \
	apt install -y protobuf-compiler clang

WORKDIR /usr/src/hydradx-node

COPY . .

RUN cargo build

FROM ubuntu:22.04
LABEL org.opencontainers.image.source = "https://github.com/galacticcouncil/HydraDX-node"

RUN useradd -m -u 1000 -U -s /bin/sh -d /hydra hydra && \
	mkdir -p /hydra/.local/share && \
	chown -R hydra:hydra /hydra

COPY --from=builder /usr/src/hydradx-node/target/release/hydradx /usr/local/bin/hydradx

RUN chmod +x /usr/local/bin/hydradx

USER hydra
EXPOSE 30333 9933 9944 9615
VOLUME ["/hydra/.local/share"]

ENTRYPOINT ["/usr/local/bin/hydradx"]
CMD ["--prometheus-external", "--", "--execution=wasm" ,"--telemetry-url", "wss://telemetry.hydradx.io:9000/submit/ 0"]
``` 