### PR TITLE
feat: forbid XYK pools containing LRNA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3830,7 +3830,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "180.0.0"
+version = "181.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -10219,7 +10219,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.12.2"
+version = "1.12.3"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.12.2"
+version = "1.12.3"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/call_filter.rs
+++ b/integration-tests/src/call_filter.rs
@@ -207,6 +207,23 @@ fn transfer_should_not_work_when_transfering_omnipool_assets_to_omnipool_account
 }
 
 #[test]
+fn xyk_create_pool_with_lrna_should_be_filtered_by_call_filter() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		// the values here don't need to make sense, all we need is a valid Call
+		let call = hydradx_runtime::RuntimeCall::XYK(pallet_xyk::Call::create_pool {
+			asset_a: LRNA,
+			amount_a: UNITS,
+			asset_b: DOT,
+			amount_b: UNITS,
+		});
+
+		assert!(!hydradx_runtime::CallFilter::contains(&call));
+	});
+}
+
+#[test]
 fn calling_pallet_xcm_send_extrinsic_should_not_be_filtered_by_call_filter() {
 	TestNet::reset();
 

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "180.0.0"
+version = "181.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -94,7 +94,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 180,
+	spec_version: 181,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Note: Call filter is called from Transact filter, so there is no need to update Transact filter