### PR TITLE
chore: Cleanup EVM storage migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "async-trait",
  "clap 4.3.9",
@@ -4221,7 +4221,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "193.0.0"
+version = "194.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx"
-version = "11.0.0"
+version = "11.0.1"
 description = "HydraDX node"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -183,7 +183,7 @@ pub fn parachain_genesis(
 		omnipool_warehouse_lm: Default::default(),
 		omnipool_liquidity_mining: Default::default(),
 		evm_chain_id: hydradx_runtime::EVMChainIdConfig {
-			chain_id: 222_222u32.into(),
+			chain_id: 222_223u32.into(),
 		},
 		ethereum: Default::default(),
 		evm: Default::default(),

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -183,7 +183,7 @@ pub fn parachain_genesis(
 		omnipool_warehouse_lm: Default::default(),
 		omnipool_liquidity_mining: Default::default(),
 		evm_chain_id: hydradx_runtime::EVMChainIdConfig {
-			chain_id: 222_223u32.into(),
+			chain_id: 2_222_222u32.into(),
 		},
 		ethereum: Default::default(),
 		evm: Default::default(),

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "193.0.0"
+version = "194.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -99,7 +99,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 193,
+	spec_version: 194,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/hydradx/src/migrations.rs
+++ b/runtime/hydradx/src/migrations.rs
@@ -1,11 +1,7 @@
 #![allow(unused_imports)]
-use crate::Vec;
-use frame_support::{codec::alloc::vec, traits::OnRuntimeUpgrade, weights::Weight};
+use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
 
 pub struct OnRuntimeUpgradeMigration;
-
-use crate::Runtime;
-use pallet_evm_chain_id::ChainId;
 
 impl OnRuntimeUpgrade for OnRuntimeUpgradeMigration {
 	#[cfg(feature = "try-runtime")]
@@ -14,9 +10,7 @@ impl OnRuntimeUpgrade for OnRuntimeUpgradeMigration {
 	}
 
 	fn on_runtime_upgrade() -> Weight {
-		let evm_id: u64 = 222_222u64;
-		ChainId::<Runtime>::put(evm_id);
-		<Runtime as frame_system::Config>::DbWeight::get().reads_writes(0, 1)
+		Weight::zero()
 	}
 
 	#[cfg(feature = "try-runtime")]

--- a/runtime/hydradx/src/migrations.rs
+++ b/runtime/hydradx/src/migrations.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
 use crate::Vec;
-use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
+use frame_support::{codec::alloc::vec, traits::OnRuntimeUpgrade, weights::Weight};
 pub struct OnRuntimeUpgradeMigration;
 
 impl OnRuntimeUpgrade for OnRuntimeUpgradeMigration {

--- a/runtime/hydradx/src/migrations.rs
+++ b/runtime/hydradx/src/migrations.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
+use crate::Vec;
 use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
-
 pub struct OnRuntimeUpgradeMigration;
 
 impl OnRuntimeUpgrade for OnRuntimeUpgradeMigration {


### PR DESCRIPTION
Removes the chainId migration introduced in https://github.com/galacticcouncil/HydraDX-node/pull/646

Also, it sets a different chainId in the chain_spec