### PR TITLE
chore: Makefile update,  run non-release tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ build-benchmarks:
 
 .PHONY: test
 test:
+	cargo test --locked
+
+.PHONY: test-release
+test-release:
 	cargo test --release --locked
 
 .PHONY: test-benchmarks


### PR DESCRIPTION

## Description
Removed `--release` from from `make test`  to have stricter checks.
