### PR TITLE
ci: add write permission for version-check job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,6 +140,8 @@ jobs:
 
   version-check:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     if: github.event_name == 'pull_request'
     outputs:
       runtime-upgraded: ${{ steps.check-runtime.outputs.upgraded }}


### PR DESCRIPTION
Should fix the error from `version-check` job:
`Error: Resource not accessible by integration`