### PR TITLE
feat: add Helikon boot node for HydraDX

### DIFF
--- a/node/res/hydradx.json
+++ b/node/res/hydradx.json
@@ -5,7 +5,9 @@
   "bootNodes": [
     "/dns/p2p-01.hydra.hydradx.io/tcp/30333/p2p/12D3KooWHzv7XVVBwY4EX1aKJBU6qzEjqGk6XtoFagr5wEXx6MsH",
     "/dns/p2p-02.hydra.hydradx.io/tcp/30333/p2p/12D3KooWR72FwHrkGNTNes6U5UHQezWLmrKu6b45MvcnRGK8J3S6",
-    "/dns/p2p-03.hydra.hydradx.io/tcp/30333/p2p/12D3KooWFDwxZinAjgmLVgsideCmdB2bz911YgiQdLEiwKovezUz"
+    "/dns/p2p-03.hydra.hydradx.io/tcp/30333/p2p/12D3KooWFDwxZinAjgmLVgsideCmdB2bz911YgiQdLEiwKovezUz",
+    "/dns4/boot.helikon.io/tcp/15120/p2p/12D3KooWDcQY1L2ny3F7YPyP4snCZZYc4eKWgPLEzdBvWBUjH5Yt",
+    "/dns4/boot.helikon.io/tcp/15125/wss/p2p/12D3KooWDcQY1L2ny3F7YPyP4snCZZYc4eKWgPLEzdBvWBUjH5Yt"
   ],
   "telemetryEndpoints": [
     [


### PR DESCRIPTION
## Description
This PR adds the Helikon boot node (through `p2p` and `wss/p2p`) to the HydraDX chain specification at [/node/res/hydradx.json](https://github.com/galacticcouncil/HydraDX-node/blob/master/node/res/hydradx.json).

## How Has This Been Tested?

To test:

```
./hydradx --chain hydradx --tmp --reserved-only --reserved-nodes "/dns4/boot.helikon.io/tcp/15120/p2p/12D3KooWDcQY1L2ny3F7YPyP4snCZZYc4eKWgPLEzdBvWBUjH5Yt"
./hydradx --chain hydradx --tmp --reserved-only --reserved-nodes "/dns4/boot.helikon.io/tcp/15125/wss/p2p/12D3KooWDcQY1L2ny3F7YPyP4snCZZYc4eKWgPLEzdBvWBUjH5Yt"
```

## Checklist:
- [ ] I have updated the documentation if necessary.
- [ ] I have added tests to cover my changes, regression test if fixing an issue.
- [ ] This is a breaking change.
