### PR TITLE
feat: Allow Asset Hub as a reserve for Foreign Assets

### DIFF
--- a/runtime/hydradx/src/xcm.rs
+++ b/runtime/hydradx/src/xcm.rs
@@ -103,6 +103,8 @@ parameter_types! {
   pub AssetHubLocation: MultiLocation = (Parent, Parachain(1000)).into();
 }
 
+/// Matches foreign assets from a given origin.
+/// Foreign assets are assets bridged from other consensus systems. i.e parents > 1.
 pub struct IsForeignNativeAsset<Origin>(PhantomData<Origin>);
 impl<Origin> ContainsPair<MultiAsset, MultiLocation> for IsForeignNativeAsset<Origin>
 where

--- a/runtime/hydradx/src/xcm.rs
+++ b/runtime/hydradx/src/xcm.rs
@@ -12,7 +12,7 @@ use cumulus_primitives_core::ParaId;
 use frame_support::{
 	parameter_types,
 	sp_runtime::traits::{AccountIdConversion, Convert},
-	traits::{ConstU32, Contains, Everything, Get, Nothing},
+	traits::{ConstU32, Contains, ContainsPair, Everything, Get, Nothing},
 	PalletId,
 };
 use frame_system::EnsureRoot;
@@ -99,7 +99,32 @@ parameter_types! {
 	pub const MaxNumberOfInstructions: u16 = 100;
 
 	pub UniversalLocation: InteriorMultiLocation = X2(GlobalConsensus(RelayNetwork::get()), Parachain(ParachainInfo::parachain_id().into()));
+
+  pub AssetHubLocation: MultiLocation = (Parent, Parachain(1000)).into();
 }
+
+pub struct IsForeignNativeAsset<Origin>(PhantomData<Origin>);
+impl<Origin> ContainsPair<MultiAsset, MultiLocation> for IsForeignNativeAsset<Origin>
+where
+	Origin: Get<MultiLocation>,
+{
+	fn contains(asset: &MultiAsset, origin: &MultiLocation) -> bool {
+		let loc = Origin::get();
+		&loc == origin
+			&& matches!(
+				asset,
+				MultiAsset {
+					id: Concrete(MultiLocation { parents: 2, .. }),
+					fun: Fungible(_),
+				},
+			)
+	}
+}
+
+pub type Reserves = (
+	IsForeignNativeAsset<AssetHubLocation>,
+	MultiNativeAsset<AbsoluteReserveProvider>,
+);
 
 pub struct XcmConfig;
 impl Config for XcmConfig {
@@ -108,7 +133,7 @@ impl Config for XcmConfig {
 
 	type AssetTransactor = LocalAssetTransactor;
 	type OriginConverter = XcmOriginToCallOrigin;
-	type IsReserve = MultiNativeAsset<AbsoluteReserveProvider>;
+	type IsReserve = Reserves;
 
 	type IsTeleporter = (); // disabled
 	type UniversalLocation = UniversalLocation;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- We are using semantinc pull request to make our lives easier -->
<!--- Please use prefixes for the title and use ! before : if breaking like below -->
<!--- build: ci: docs: feat: perf: refactor: fix: style: test: refactor!: -->

## Description
Assets bridged from other consensus systems using the new Bridge Hub system parachain are held in reserve in Asset Hub. Asset Hub contains a second instance of the `pallet-assets` called the `foreignAssets` where bridged assets are registered. Foreign assets have a `parents` field > 1.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue below using keyword like: Fixes: #0 -->

## Motivation and Context
Make swaps and pools using foreign assets on HydraDX, specifically assets from Snowbridge. https://github.com/Snowfork/snowbridge
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
TODO: Add a new integration test to integration-tests/src/cross_chain_transfer.rs which tests receiving a foreign asset from assethub.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation if necessary.
- [ ] I have added tests to cover my changes, regression test if fixing an issue.
- [ ] This is a breaking change.
