### PR TITLE
chore: prevent to run asset-registry's v2 migration second time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4621,7 +4621,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "220.0.0"
+version = "221.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6985,7 +6985,7 @@ checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "pallet-asset-registry"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/pallets/asset-registry/Cargo.toml
+++ b/pallets/asset-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-asset-registry"
-version = "3.1.0"
+version = "3.1.1"
 description = "Pallet for asset registry management"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/asset-registry/src/migration.rs
+++ b/pallets/asset-registry/src/migration.rs
@@ -109,6 +109,14 @@ pub mod v2 {
 	}
 
 	pub fn migrate<T: Config<AssetId = u32>>() -> Weight {
+		if StorageVersion::get::<Pallet<T>>() != 1 {
+			log::info!(
+				target: "runtime::asset-registry",
+				"Nothing to migratte, pallet's version is not 1."
+			);
+			return T::DbWeight::get().reads_writes(1, 0);
+		}
+
 		log::info!(
 			target: "runtime::asset-registry",
 			"Running migration to v2 for Asset Registry"

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "220.0.0"
+version = "221.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -108,7 +108,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 220,
+	spec_version: 221,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION

## Description
This PR prevents to run migration of asset-registry from v1 to v2 if pallet's version is not `1`.
