### PR TITLE
fix: swaps of insufficient asset via evm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4621,7 +4621,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "227.0.0"
+version = "228.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -11392,7 +11392,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.20.1"
+version = "1.20.2"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8592,7 +8592,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-multi-payment"
-version = "9.5.0"
+version = "9.6.0"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.20.1"
+version = "1.20.2"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/evm.rs
+++ b/integration-tests/src/evm.rs
@@ -3,10 +3,12 @@
 use crate::{assert_balance, polkadot_test_net::*};
 use fp_evm::{Context, Transfer};
 use fp_rpc::runtime_decl_for_ethereum_runtime_rpc_api::EthereumRuntimeRPCApi;
+use frame_support::storage::with_transaction;
 use frame_support::{assert_ok, dispatch::GetDispatchInfo, sp_runtime::codec::Encode, traits::Contains};
 use frame_system::RawOrigin;
 use hex_literal::hex;
 use hydradx_runtime::evm::ExtendedAddressMapping;
+use hydradx_runtime::XYK;
 use hydradx_runtime::{
 	evm::precompiles::{
 		addr,
@@ -17,12 +19,15 @@ use hydradx_runtime::{
 	AssetRegistry, Balances, CallFilter, Currencies, EVMAccounts, Omnipool, RuntimeCall, RuntimeOrigin, Tokens,
 	TransactionPause, EVM,
 };
+use hydradx_traits::AssetKind;
+use hydradx_traits::Create;
 use orml_traits::MultiCurrency;
 use pallet_evm::*;
 use pretty_assertions::assert_eq;
 use primitives::{AssetId, Balance};
 use sp_core::{blake2_256, H160, H256, U256};
-use sp_runtime::{traits::SignedExtension, FixedU128, Permill};
+use sp_runtime::TransactionOutcome;
+use sp_runtime::{traits::SignedExtension, DispatchError, FixedU128, Permill};
 use std::borrow::Cow;
 use xcm_emulator::TestExt;
 
@@ -1120,6 +1125,103 @@ fn dispatch_should_work_with_transfer() {
 }
 
 #[test]
+fn dispatch_should_work_with_buying_insufficient_asset() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		//Set up to idle state where the chain is not utilized at all
+		pallet_transaction_payment::pallet::NextFeeMultiplier::<hydradx_runtime::Runtime>::put(
+			hydradx_runtime::MinimumMultiplier::get(),
+		);
+		assert_ok!(EVMAccounts::bind_evm_address(hydradx_runtime::RuntimeOrigin::signed(
+			ALICE.into()
+		)));
+
+		//Create inssufficient asset
+		let shitcoin = with_transaction::<u32, DispatchError, _>(|| {
+			let name = b"SHITCO".to_vec();
+			let shitcoin = AssetRegistry::register_insufficient_asset(
+				None,
+				Some(name.try_into().unwrap()),
+				AssetKind::External,
+				Some(1_000),
+				None,
+				None,
+				None,
+				None,
+			)
+			.unwrap();
+
+			TransactionOutcome::Commit(Ok(shitcoin))
+		})
+		.unwrap();
+
+		create_xyk_pool_with_amounts(shitcoin, 1000000 * UNITS, HDX, 1000000 * UNITS);
+		let evm_address = EVMAccounts::evm_address(&Into::<AccountId>::into(ALICE));
+		init_omnipool_with_oracle_for_block_10();
+
+		assert_ok!(hydradx_runtime::Currencies::update_balance(
+			hydradx_runtime::RuntimeOrigin::root(),
+			currency_precompile::alice_substrate_evm_addr().into(),
+			WETH,
+			(100 * UNITS * 1_000_000) as i128,
+		));
+		assert_ok!(hydradx_runtime::MultiTransactionPayment::set_currency(
+			hydradx_runtime::RuntimeOrigin::signed(ALICE.into()),
+			WETH,
+		));
+
+		let swap_route = vec![
+			Trade {
+				pool: PoolType::Omnipool,
+				asset_in: WETH,
+				asset_out: HDX,
+			},
+			Trade {
+				pool: PoolType::XYK,
+				asset_in: HDX,
+				asset_out: shitcoin,
+			},
+		];
+		let router_swap = RuntimeCall::Router(pallet_route_executor::Call::buy {
+			asset_in: WETH,
+			asset_out: shitcoin,
+			amount_out: 1 * UNITS,
+			max_amount_in: u128::MAX,
+			route: swap_route.clone(),
+		});
+
+		//Arrange
+		let data = router_swap.encode();
+		let (gas_price, _) = hydradx_runtime::DynamicEvmFee::min_gas_price();
+
+		hydradx_finalize_block(); //We do this to simulate that we don't have any prices in multi-payment-pallet, but the prices can be still calculated based on onchain route
+
+		let init_balance = Tokens::free_balance(shitcoin, &currency_precompile::alice_substrate_evm_addr());
+		assert_eq!(init_balance, 0);
+
+		// Act
+		assert_ok!(EVM::call(
+			evm_signed_origin(currency_precompile::alice_evm_addr()),
+			currency_precompile::alice_evm_addr(),
+			DISPATCH_ADDR,
+			data,
+			U256::from(0),
+			1000000,
+			gas_price * 10,
+			None,
+			Some(U256::zero()),
+			[].into()
+		));
+
+		//EVM call passes even when the substrate tx fails, so we need to check if the tx is executed
+		expect_hydra_events(vec![pallet_evm::Event::Executed { address: DISPATCH_ADDR }.into()]);
+		let new_balance = Tokens::free_balance(shitcoin, &currency_precompile::alice_substrate_evm_addr());
+		assert_eq!(new_balance, 1 * UNITS);
+	});
+}
+
+#[test]
 fn dispatch_transfer_should_not_work_with_insufficient_fees() {
 	TestNet::reset();
 
@@ -1500,6 +1602,8 @@ fn do_trade_to_populate_oracle(asset_1: AssetId, asset_2: AssetId, amount: Balan
 }
 
 use frame_support::traits::fungible::Mutate;
+use hydradx_traits::router::{PoolType, Trade};
+
 pub fn init_omnipol() {
 	let native_price = FixedU128::from_rational(29903049701668757, 73927734532192294158);
 	let dot_price = FixedU128::from_rational(103158291366950047, 4566210555614178);
@@ -1635,4 +1739,27 @@ impl PrecompileHandle for MockHandle {
 	fn gas_limit(&self) -> Option<u64> {
 		None
 	}
+}
+
+fn create_xyk_pool_with_amounts(asset_a: u32, amount_a: u128, asset_b: u32, amount_b: u128) {
+	assert_ok!(Currencies::update_balance(
+		hydradx_runtime::RuntimeOrigin::root(),
+		DAVE.into(),
+		asset_a,
+		amount_a as i128,
+	));
+	assert_ok!(Currencies::update_balance(
+		hydradx_runtime::RuntimeOrigin::root(),
+		DAVE.into(),
+		asset_b,
+		amount_b as i128,
+	));
+
+	assert_ok!(XYK::create_pool(
+		RuntimeOrigin::signed(DAVE.into()),
+		asset_a,
+		amount_a,
+		asset_b,
+		amount_b,
+	));
 }

--- a/integration-tests/src/polkadot_test_net.rs
+++ b/integration-tests/src/polkadot_test_net.rs
@@ -662,6 +662,16 @@ pub fn hydradx_run_to_block(to: BlockNumber) {
 	}
 }
 
+pub fn hydradx_finalize_block() {
+	use frame_support::traits::OnFinalize;
+
+	let b = hydradx_runtime::System::block_number();
+
+	hydradx_runtime::System::on_finalize(b);
+	hydradx_runtime::EmaOracle::on_finalize(b);
+	hydradx_runtime::MultiTransactionPayment::on_finalize(b);
+}
+
 pub fn polkadot_run_to_block(to: BlockNumber) {
 	use frame_support::traits::OnFinalize;
 

--- a/pallets/transaction-multi-payment/Cargo.toml
+++ b/pallets/transaction-multi-payment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-transaction-multi-payment"
-version = "9.5.0"
+version = "9.6.0"
 description = "Transaction multi currency payment support module"
 authors = ["GalacticCoucil"]
 edition = "2021"

--- a/pallets/transaction-multi-payment/src/lib.rs
+++ b/pallets/transaction-multi-payment/src/lib.rs
@@ -522,9 +522,8 @@ where
 }
 
 /// We provide an oracle for the price of all currencies accepted as fee payment.
-/// First we try to get the price from cache, otherwise we calculate it
-/// The else statement for calculating price based onchain route is used by EVM dry run
-/// as in the dry run we dont have storage filled with prices
+/// In the else statement, first we try to get the price from cache, otherwise we calculate it
+/// The price calculation based on onchain-route is mainly used by EVM dry run as in the dry run we dont have storage filled with prices, so calculation is needed
 impl<T: Config> NativePriceOracle<AssetIdOf<T>, Price> for Pallet<T> {
 	fn price(currency: AssetIdOf<T>) -> Option<Price> {
 		if currency == T::NativeAssetId::get() {

--- a/pallets/transaction-multi-payment/src/lib.rs
+++ b/pallets/transaction-multi-payment/src/lib.rs
@@ -522,12 +522,15 @@ where
 }
 
 /// We provide an oracle for the price of all currencies accepted as fee payment.
+/// First we try to get the price from cache, otherwise we calculate it
+/// The else statement for calculating price based onchain route is used by EVM dry run
+/// as in the dry run we dont have storage filled with prices
 impl<T: Config> NativePriceOracle<AssetIdOf<T>, Price> for Pallet<T> {
 	fn price(currency: AssetIdOf<T>) -> Option<Price> {
 		if currency == T::NativeAssetId::get() {
 			Some(Price::one())
 		} else {
-			Pallet::<T>::currency_price(currency)
+			Pallet::<T>::currency_price(currency).or_else(|| Self::get_oracle_price(currency, T::NativeAssetId::get()))
 		}
 	}
 }

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "227.0.0"
+version = "228.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"

--- a/runtime/hydradx/src/assets.rs
+++ b/runtime/hydradx/src/assets.rs
@@ -23,7 +23,6 @@ use hydradx_adapters::{
 	AssetFeeOraclePriceProvider, EmaOraclePriceAdapter, FreezableNFT, MultiCurrencyLockedBalance, OmnipoolHookAdapter,
 	OracleAssetVolumeProvider, PriceAdjustmentAdapter, StableswapHooksAdapter, VestingInfo,
 };
-
 use hydradx_adapters::{RelayChainBlockHashProvider, RelayChainBlockNumberProvider};
 use hydradx_traits::{
 	registry::Inspect,
@@ -44,7 +43,7 @@ use primitives::constants::{
 	chain::OMNIPOOL_SOURCE,
 	currency::{NATIVE_EXISTENTIAL_DEPOSIT, UNITS},
 };
-use sp_runtime::{traits::Zero, DispatchError, DispatchResult, FixedPointNumber};
+use sp_runtime::{traits::Zero, ArithmeticError, DispatchError, DispatchResult, FixedPointNumber};
 
 use core::ops::RangeInclusive;
 use frame_support::{
@@ -108,12 +107,32 @@ impl pallet_balances::Config for Runtime {
 }
 
 pub struct CurrencyHooks;
+
+#[cfg(not(feature = "runtime-benchmarks"))]
+pub type AssetPriceOracle = AssetFeeOraclePriceProvider<
+	NativeAssetId,
+	crate::MultiTransactionPayment,
+	crate::Router,
+	OraclePriceProvider<AssetId, crate::EmaOracle, LRNA>,
+	crate::MultiTransactionPayment,
+	EmaOracleSpotPriceShort,
+>;
+#[cfg(feature = "runtime-benchmarks")]
+pub type AssetPriceOracle = AssetFeeOraclePriceProvider<
+	NativeAssetId,
+	crate::MultiTransactionPayment,
+	crate::Router,
+	DummyOraclePriceProvider,
+	crate::MultiTransactionPayment,
+	EmaOracleSpotPriceShort,
+>;
+
 impl MutationHooks<AccountId, AssetId, Balance> for CurrencyHooks {
 	type OnDust = Duster;
 	type OnSlash = ();
-	type PreDeposit = SufficiencyCheck;
+	type PreDeposit = SufficiencyCheck<AssetPriceOracle>;
 	type PostDeposit = ();
-	type PreTransfer = SufficiencyCheck;
+	type PreTransfer = SufficiencyCheck<AssetPriceOracle>;
 	type PostTransfer = ();
 	type OnNewTokenAccount = AddTxAssetOnAccount<Runtime>;
 	type OnKilledTokenAccount = (RemoveTxAssetOnKilled<Runtime>, OnKilledTokenAccount);
@@ -128,8 +147,13 @@ parameter_types! {
 		.saturating_mul_int(<Runtime as pallet_balances::Config>::ExistentialDeposit::get());
 }
 
-pub struct SufficiencyCheck;
-impl SufficiencyCheck {
+pub struct SufficiencyCheck<PriceOracle>(PhantomData<PriceOracle>);
+
+//pub struct SufficiencyCheck;
+impl<PriceOracle> SufficiencyCheck<PriceOracle>
+where
+	PriceOracle: NativePriceOracle<AssetId, hydra_dx_math::ema::EmaPrice>,
+{
 	/// This function is used by `orml-toknes::MutationHooks` before a transaction is executed.
 	/// It is called from `PreDeposit` and `PreTransfer`.
 	/// If transferred asset is not sufficient asset, it calculates ED amount in user's fee asset
@@ -171,8 +195,14 @@ impl SufficiencyCheck {
 		if !orml_tokens::Accounts::<Runtime>::contains_key(to, asset) && !AssetRegistry::is_sufficient(asset) {
 			let fee_payment_asset = MultiTransactionPayment::account_currency(paying_account);
 
-			let ed_in_fee_asset = MultiTransactionPayment::price(fee_payment_asset)
-				.ok_or(pallet_transaction_multi_payment::Error::<Runtime>::UnsupportedCurrency)?
+			let fee_payment_asset_native_price = PriceOracle::price(fee_payment_asset)
+				.ok_or(pallet_transaction_multi_payment::Error::<Runtime>::UnsupportedCurrency)?;
+
+			let fee_payment_asset_native_price =
+				FixedU128::checked_from_rational(fee_payment_asset_native_price.n, fee_payment_asset_native_price.d)
+					.ok_or(ArithmeticError::DivisionByZero)?;
+
+			let ed_in_fee_asset = fee_payment_asset_native_price
 				.saturating_mul_int(InsufficientEDinHDX::get())
 				.max(1);
 
@@ -217,7 +247,7 @@ impl SufficiencyCheck {
 	}
 }
 
-impl OnTransfer<AccountId, AssetId, Balance> for SufficiencyCheck {
+impl OnTransfer<AccountId, AssetId, Balance> for SufficiencyCheck<AssetPriceOracle> {
 	fn on_transfer(asset: AssetId, from: &AccountId, to: &AccountId, _amount: Balance) -> DispatchResult {
 		//NOTE: `to` is paying ED if `from` is whitelisted.
 		//This can happen if pallet's account transfers insufficient tokens to another account.
@@ -229,7 +259,7 @@ impl OnTransfer<AccountId, AssetId, Balance> for SufficiencyCheck {
 	}
 }
 
-impl OnDeposit<AccountId, AssetId, Balance> for SufficiencyCheck {
+impl OnDeposit<AccountId, AssetId, Balance> for SufficiencyCheck<AssetPriceOracle> {
 	fn on_deposit(asset: AssetId, to: &AccountId, _amount: Balance) -> DispatchResult {
 		Self::on_funds(asset, to, to)
 	}

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -109,7 +109,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 227,
+	spec_version: 228,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
The operation fails already when MM does a dry-run estimateGas(...) on the transaction.  When insufficient asset is bought, on_funds is triggered where we try to retrieve the price of the fee payment asset from the multi-pallet: https://github.com/galacticcouncil/HydraDX-node/blob/8abf856afa839b798c4e39e38af2b2901f55739b/runtime/hydradx/src/assets.rs#L174

But at the point of dry-run, the storage is empty, so it doesn't contain the accepted currency prices, as they are populated only  in on_initialize of multi pallet.

The solution is to calculate the oracle onchain price directly instead of getting the prices from an empty prices storage of MultiPaymentPallet