### PR TITLE
fix: runtime build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4671,7 +4671,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "238.0.0"
+version = "239.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "238.0.0"
+version = "239.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"
@@ -311,6 +311,7 @@ std = [
     "pallet-evm-accounts-rpc-runtime-api/std",
     "pallet-xyk-liquidity-mining/std",
     "pallet-state-trie-migration/std",
+    "pallet-evm-precompile-call-permit/std",
 ]
 try-runtime= [
     "frame-try-runtime",

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -109,7 +109,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 238,
+	spec_version: 239,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This PR fixes the following error produced when the runtime is build:
`error: cannot find macro thread_local in this scope
   --> precompiles/utils/src/evm/handle.rs:111:1
    |
111 | environmental::environmental!(EVM_CONTEXT: trait PrecompileHandle);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: thread_local is in scope, but it is an attribute: #[thread_local]`