### PR TITLE
refactor: use genesis builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4769,7 +4769,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "async-trait",
  "clap 4.5.4",
@@ -4849,6 +4849,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-state-machine",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.7.2)",
  "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.7.2)",
  "sp-timestamp",
  "sp-transaction-pool",
@@ -4911,7 +4912,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-runtime"
-version = "242.0.0"
+version = "243.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -5024,6 +5025,7 @@ dependencies = [
  "sp-consensus-aura",
  "sp-core",
  "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.7.2)",
+ "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
  "sp-offchain",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4769,7 +4769,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx"
-version = "13.0.1"
+version = "13.1.0"
 dependencies = [
  "async-trait",
  "clap 4.5.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release
 sp-arithmetic = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.7.2", default-features = false }
 sp-authority-discovery = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.7.2", default-features = false }
 sp-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.7.2", default-features = false }
+sp-genesis-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.7.2", default-features = false }
 sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.7.2", default-features = false }
 sp-consensus = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.7.2", default-features = false }
 sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.7.2", default-features = false }
@@ -347,6 +348,7 @@ sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release
 sp-arithmetic = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.7.2" }
 sp-authority-discovery = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.7.2" }
 sp-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.7.2" }
+sp-genesis-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.7.2" }
 sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.7.2" }
 sp-consensus = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.7.2" }
 sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.7.2" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx"
-version = "13.0.1"
+version = "13.1.0"
 description = "HydraDX node"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx"
-version = "13.0.0"
+version = "13.0.1"
 description = "HydraDX node"
 authors = ["GalacticCouncil"]
 edition = "2021"
@@ -54,6 +54,7 @@ sc-transaction-pool = { workspace = true }
 sc-transaction-pool-api = { workspace = true }
 sc-sysinfo = { workspace = true }
 sp-api = { workspace = true }
+sp-std = { workspace = true }
 sp-block-builder = { workspace = true }
 sp-blockchain = { workspace = true }
 sp-consensus = { workspace = true }

--- a/node/src/chain_spec/local.rs
+++ b/node/src/chain_spec/local.rs
@@ -10,142 +10,134 @@ pub fn parachain_config() -> Result<ChainSpec, String> {
 	properties.insert("tokenDecimals".into(), TOKEN_DECIMALS.into());
 	properties.insert("tokenSymbol".into(), TOKEN_SYMBOL.into());
 
-	#[allow(deprecated)]
-	Ok(ChainSpec::from_genesis(
-		// Name
-		"HydraDX Local Testnet",
-		// ID
-		"local_testnet",
-		ChainType::Local,
-		move || {
-			parachain_genesis(
-				// Sudo account
-				get_account_id_from_seed::<sr25519::Public>("Alice"),
-				// initial authorities & invulnerables
+	let genesis_json = parachain_genesis(
+		// Sudo account
+		get_account_id_from_seed::<sr25519::Public>("Alice"),
+		// initial authorities & invulnerables
+		(
+			vec![
 				(
-					vec![
-						(
-							get_account_id_from_seed::<sr25519::Public>("Alice"),
-							get_from_seed::<AuraId>("Alice"),
-						),
-						(
-							get_account_id_from_seed::<sr25519::Public>("Bob"),
-							get_from_seed::<AuraId>("Bob"),
-						),
-					],
-					// candidacy bond
-					10_000 * UNITS,
-				),
-				// Pre-funded accounts
-				vec![
-					(get_account_id_from_seed::<sr25519::Public>("Alice"), INITIAL_BALANCE),
-					(get_account_id_from_seed::<sr25519::Public>("Bob"), INITIAL_BALANCE),
-					(get_account_id_from_seed::<sr25519::Public>("Charlie"), INITIAL_BALANCE),
-					(get_account_id_from_seed::<sr25519::Public>("Dave"), INITIAL_BALANCE),
-					(get_account_id_from_seed::<sr25519::Public>("Eve"), INITIAL_BALANCE),
-					(get_account_id_from_seed::<sr25519::Public>("Ferdie"), INITIAL_BALANCE),
-					(
-						get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-						INITIAL_BALANCE,
-					),
-					(
-						get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-						INITIAL_BALANCE,
-					),
-					(
-						get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-						INITIAL_BALANCE,
-					),
-					(
-						get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-						INITIAL_BALANCE,
-					),
-					(
-						get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-						INITIAL_BALANCE,
-					),
-					(
-						get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
-						INITIAL_BALANCE,
-					),
-				],
-				// council members
-				vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
-				// technical committee members
-				vec![
 					get_account_id_from_seed::<sr25519::Public>("Alice"),
+					get_from_seed::<AuraId>("Alice"),
+				),
+				(
 					get_account_id_from_seed::<sr25519::Public>("Bob"),
-					get_account_id_from_seed::<sr25519::Public>("Eve"),
-				],
-				// vestings
-				vec![],
-				// registered assets
-				vec![
-					(
-						Some(1),
-						Some(b"KSM".to_vec().try_into().expect("Name is too long")),
-						1_000u128,
-						None,
-						None,
-						None,
-						true,
-					),
-					(
-						Some(2),
-						Some(b"KUSD".to_vec().try_into().expect("Name is too long")),
-						1_000u128,
-						None,
-						None,
-						None,
-						true,
-					),
-				],
-				// accepted assets
-				vec![(1, Price::from_float(0.0000212)), (2, Price::from_float(0.000806))],
-				// token balances
-				vec![
-					(
-						get_account_id_from_seed::<sr25519::Public>("Alice"),
-						vec![(1, INITIAL_TOKEN_BALANCE), (2, INITIAL_TOKEN_BALANCE)],
-					),
-					(
-						get_account_id_from_seed::<sr25519::Public>("Bob"),
-						vec![(1, INITIAL_TOKEN_BALANCE), (2, INITIAL_TOKEN_BALANCE)],
-					),
-				],
-				// claims data
-				create_testnet_claims(),
-				// elections
-				vec![
-					(get_account_id_from_seed::<sr25519::Public>("Alice"), STASH / 5),
-					(get_account_id_from_seed::<sr25519::Public>("Bob"), STASH / 5),
-					(get_account_id_from_seed::<sr25519::Public>("Eve"), STASH / 5),
-				],
-				// parachain ID
-				PARA_ID.into(),
-				DusterConfig {
-					account_blacklist: vec![get_account_id_from_seed::<sr25519::Public>("Duster")],
-					reward_account: Some(get_account_id_from_seed::<sr25519::Public>("Duster")),
-					dust_account: Some(get_account_id_from_seed::<sr25519::Public>("Duster")),
-				},
-			)
-		},
-		// Bootnodes
+					get_from_seed::<AuraId>("Bob"),
+				),
+			],
+			// candidacy bond
+			10_000 * UNITS,
+		),
+		// Pre-funded accounts
+		vec![
+			(get_account_id_from_seed::<sr25519::Public>("Alice"), INITIAL_BALANCE),
+			(get_account_id_from_seed::<sr25519::Public>("Bob"), INITIAL_BALANCE),
+			(get_account_id_from_seed::<sr25519::Public>("Charlie"), INITIAL_BALANCE),
+			(get_account_id_from_seed::<sr25519::Public>("Dave"), INITIAL_BALANCE),
+			(get_account_id_from_seed::<sr25519::Public>("Eve"), INITIAL_BALANCE),
+			(get_account_id_from_seed::<sr25519::Public>("Ferdie"), INITIAL_BALANCE),
+			(
+				get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
+				INITIAL_BALANCE,
+			),
+			(
+				get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+				INITIAL_BALANCE,
+			),
+			(
+				get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
+				INITIAL_BALANCE,
+			),
+			(
+				get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
+				INITIAL_BALANCE,
+			),
+			(
+				get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
+				INITIAL_BALANCE,
+			),
+			(
+				get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+				INITIAL_BALANCE,
+			),
+		],
+		// council members
+		vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
+		// technical committee members
+		vec![
+			get_account_id_from_seed::<sr25519::Public>("Alice"),
+			get_account_id_from_seed::<sr25519::Public>("Bob"),
+			get_account_id_from_seed::<sr25519::Public>("Eve"),
+		],
+		// vestings
 		vec![],
-		// Telemetry
-		None,
-		// Protocol ID
-		Some(PROTOCOL_ID),
-		// Fork ID
-		None,
-		// Properties
-		Some(properties),
-		// Extensions
+		// registered assets
+		vec![
+			(
+				Some(1),
+				Some(b"KSM".to_vec().try_into().expect("Name is too long")),
+				1_000u128,
+				None,
+				None,
+				None,
+				true,
+			),
+			(
+				Some(2),
+				Some(b"KUSD".to_vec().try_into().expect("Name is too long")),
+				1_000u128,
+				None,
+				None,
+				None,
+				true,
+			),
+		],
+		// accepted assets
+		vec![(1, Price::from_float(0.0000212)), (2, Price::from_float(0.000806))],
+		// token balances
+		vec![
+			(
+				get_account_id_from_seed::<sr25519::Public>("Alice"),
+				vec![(1, INITIAL_TOKEN_BALANCE), (2, INITIAL_TOKEN_BALANCE)],
+			),
+			(
+				get_account_id_from_seed::<sr25519::Public>("Bob"),
+				vec![(1, INITIAL_TOKEN_BALANCE), (2, INITIAL_TOKEN_BALANCE)],
+			),
+		],
+		// claims data
+		create_testnet_claims(),
+		// elections
+		vec![
+			(get_account_id_from_seed::<sr25519::Public>("Alice"), STASH / 5),
+			(get_account_id_from_seed::<sr25519::Public>("Bob"), STASH / 5),
+			(get_account_id_from_seed::<sr25519::Public>("Eve"), STASH / 5),
+		],
+		// parachain ID
+		PARA_ID.into(),
+		DusterConfig {
+			account_blacklist: vec![get_account_id_from_seed::<sr25519::Public>("Duster")],
+			reward_account: Some(get_account_id_from_seed::<sr25519::Public>("Duster")),
+			dust_account: Some(get_account_id_from_seed::<sr25519::Public>("Duster")),
+		},
+	);
+
+	let chain_spec = ChainSpec::builder(
+		wasm_binary,
 		Extensions {
 			relay_chain: "rococo-local".into(),
 			para_id: PARA_ID,
 			evm_since: 1,
 		},
-		wasm_binary,
-	))
+	)
+	.with_name("HydraDX Local Testnet")
+	.with_id("local_testnet")
+	.with_chain_type(ChainType::Local)
+	.with_boot_nodes(vec![])
+	.with_properties(properties)
+	.with_protocol_id(PROTOCOL_ID)
+	.with_genesis_config_patch(genesis_json)
+	.build();
+
+	Ok(chain_spec)
 }

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -28,10 +28,8 @@ pub mod staging;
 use cumulus_primitives_core::ParaId;
 use hex_literal::hex;
 use hydradx_runtime::{
-	pallet_claims::EthereumAddress, AccountId, AssetRegistryConfig, AuraId, Balance, BalancesConfig, ClaimsConfig,
-	CollatorSelectionConfig, CouncilConfig, DusterConfig, ElectionsConfig, GenesisHistoryConfig,
-	MultiTransactionPaymentConfig, ParachainInfoConfig, RegistryStrLimit, RuntimeGenesisConfig, SessionConfig,
-	Signature, SystemConfig, TechnicalCommitteeConfig, TokensConfig, VestingConfig, WASM_BINARY,
+	pallet_claims::EthereumAddress, AccountId, AuraId, Balance, DusterConfig, RegistryStrLimit, RuntimeGenesisConfig,
+	Signature, WASM_BINARY,
 };
 use primitives::{
 	constants::currency::{NATIVE_EXISTENTIAL_DEPOSIT, UNITS},
@@ -115,108 +113,115 @@ pub fn parachain_genesis(
 	elections: Vec<(AccountId, Balance)>,
 	parachain_id: ParaId,
 	duster: DusterConfig,
-) -> RuntimeGenesisConfig {
-	RuntimeGenesisConfig {
-		system: SystemConfig {
-			// Add Wasm runtime to storage.
-			..Default::default()
-		},
-		session: SessionConfig {
-			keys: initial_authorities
-				.0
+) -> serde_json::Value {
+	serde_json::json!({
+	"system": {},
+	"session": {
+		"keys": initial_authorities
+			.0
+			.iter()
+			.cloned()
+			.map(|(acc, aura)| {
+				(
+					acc.clone(),                                   // account id
+					acc,                                           // validator id
+					hydradx_runtime::opaque::SessionKeys { aura }, // session keys
+				)
+			})
+			.collect::<Vec<_>>(),
+	},
+	"aura": {
+		"authorities": Vec::<sp_consensus_aura::sr25519::AuthorityId>::new()
+	},
+	"collatorSelection": {
+		"invulnerables": initial_authorities.0.iter().cloned().map(|(acc, _)| acc).collect::<Vec<_>>(),
+		"candidacyBond": initial_authorities.1,
+		"desiredCandidates": 0u32,
+	},
+	"balances": {
+		"balances": endowed_accounts
+			.iter()
+			.cloned()
+			.map(|k| (k.0.clone(), k.1 * UNITS))
+			.collect::<Vec<_>>(),
+	},
+	"council": {
+		"members": council_members,
+	},
+	"technicalCommittee": {
+		"members": tech_committee_members,
+	},
+	"vesting": { "vesting": vesting_list },
+	"assetRegistry": {
+		"registeredAssets": registered_assets.clone(),
+		"nativeAssetName": <Vec<u8> as TryInto<BoundedVec<u8, hydradx_runtime::RegistryStrLimit>>>::try_into(TOKEN_SYMBOL.as_bytes().to_vec())
+			.expect("Native asset name is too long."),
+		"nativeExistentialDeposit": NATIVE_EXISTENTIAL_DEPOSIT,
+		"nativeSymbol": <Vec<u8> as TryInto<BoundedVec<u8, hydradx_runtime::RegistryStrLimit>>>::try_into(TOKEN_SYMBOL.as_bytes().to_vec())
+			.expect("Native symbol is too long."),
+		"nativeDecimals": TOKEN_DECIMALS,
+	},
+	"multiTransactionPayment": {
+		"currencies": accepted_assets,
+		"accountCurrencies": Vec::<(AccountId, AssetId)>::new(),
+	},
+	"tokens": {
+		"balances": if registered_assets.is_empty() {
+			vec![]
+		} else {
+			token_balances
 				.iter()
-				.cloned()
-				.map(|(acc, aura)| {
-					(
-						acc.clone(),                                   // account id
-						acc,                                           // validator id
-						hydradx_runtime::opaque::SessionKeys { aura }, // session keys
-					)
+				.flat_map(|x| {
+					x.1.clone()
+						.into_iter()
+						.map(|(asset_id, amount)| (x.0.clone(), asset_id, amount))
 				})
-				.collect(),
+			.collect::<Vec<_>>()
 		},
-		// no need to pass anything, it will panic if we do. Session will take care
-		// of this.
-		aura: Default::default(),
-		collator_selection: CollatorSelectionConfig {
-			invulnerables: initial_authorities.0.iter().cloned().map(|(acc, _)| acc).collect(),
-			candidacy_bond: initial_authorities.1,
-			..Default::default()
-		},
-		balances: BalancesConfig {
-			// Configure endowed accounts with initial balance of a lot.
-			balances: endowed_accounts.iter().cloned().map(|k| (k.0, k.1 * UNITS)).collect(),
-		},
-		council: CouncilConfig {
-			// Intergalactic council member
-			members: council_members,
-			phantom: Default::default(),
-		},
-		technical_committee: TechnicalCommitteeConfig {
-			members: tech_committee_members,
-			phantom: Default::default(),
-		},
-		vesting: VestingConfig { vesting: vesting_list },
-		asset_registry: AssetRegistryConfig {
-			registered_assets: registered_assets.clone(),
-			native_asset_name: TOKEN_SYMBOL
-				.as_bytes()
-				.to_vec()
-				.try_into()
-				.expect("Native asset name is too long."),
-			native_existential_deposit: NATIVE_EXISTENTIAL_DEPOSIT,
-			native_symbol: TOKEN_SYMBOL
-				.as_bytes()
-				.to_vec()
-				.try_into()
-				.expect("Native symbol is too long."),
-			native_decimals: TOKEN_DECIMALS,
-		},
-		multi_transaction_payment: MultiTransactionPaymentConfig {
-			currencies: accepted_assets,
-			account_currencies: vec![],
-		},
-		tokens: TokensConfig {
-			balances: if registered_assets.is_empty() {
-				vec![]
-			} else {
-				token_balances
-					.iter()
-					.flat_map(|x| {
-						x.1.clone()
-							.into_iter()
-							.map(|(asset_id, amount)| (x.0.clone(), asset_id, amount))
-					})
-					.collect()
-			},
-		},
-		treasury: Default::default(),
-		elections: ElectionsConfig {
-			// Intergalactic elections
-			members: elections,
-		},
-
-		genesis_history: GenesisHistoryConfig::default(),
-		claims: ClaimsConfig { claims: claims_data },
-		parachain_info: ParachainInfoConfig {
-			parachain_id,
-			..Default::default()
-		},
-		aura_ext: Default::default(),
-		polkadot_xcm: Default::default(),
-		ema_oracle: Default::default(),
-		duster,
-		omnipool_warehouse_lm: Default::default(),
-		omnipool_liquidity_mining: Default::default(),
-		evm_chain_id: hydradx_runtime::EVMChainIdConfig {
-			chain_id: 2_222_222u32.into(),
-			..Default::default()
-		},
-		ethereum: Default::default(),
-		evm: Default::default(),
-		xyk_warehouse_lm: Default::default(),
-		xyk_liquidity_mining: Default::default(),
+	},
+	"treasury": {
+	},
+	"elections": {
+		"members": elections,
+	},
+	"genesisHistory": {
+		"previousChain": hydradx_runtime::Chain::default()
+	},
+	"claims": { "claims": claims_data },
+	"parachainInfo": {
+		"parachainId": parachain_id,
+	},
+	"auraExt": {
+	},
+	"polkadotXcm": {
+		"safeXcmVersion": hydradx_runtime::xcm::XcmGenesisConfig::<hydradx_runtime::Runtime>::default().safe_xcm_version
+	},
+	"emaOracle": {
+		"initialData": Vec::<(hydradx_runtime::Source, (AssetId, AssetId), Price, hydradx_runtime::Liquidity<Balance>)>::new()
+	},
+	"duster": {
+		"accountBlacklist": duster.account_blacklist,
+		"rewardAccount": duster.reward_account,
+		"dustAccount": duster.dust_account
+	},
+	"omnipoolWarehouseLm": {
+	},
+	"omnipoolLiquidityMining": {
+	},
+	"evmChainId": {
+		"chainId": 2_222_222u64,
+	},
+	"ethereum": {
+	},
+	"evm": {
+		"accounts": sp_std::collections::btree_map::BTreeMap::<sp_core::H160, hydradx_runtime::evm::EvmGenesisAccount>::new()
+	},
+	"xykWarehouseLm": {
+	},
+	"xykLiquidityMining": {
+	},
 	}
+	)
 }
 
 pub fn create_testnet_claims() -> Vec<(EthereumAddress, Balance)> {

--- a/node/src/chain_spec/rococo.rs
+++ b/node/src/chain_spec/rococo.rs
@@ -15,129 +15,119 @@ pub fn parachain_config() -> Result<ChainSpec, String> {
 
 pub fn _parachain_config_rococo() -> Result<ChainSpec, String> {
 	let wasm_binary = WASM_BINARY.ok_or("Development wasm binary not available".to_string())?;
+
 	let mut properties = Map::new();
 	properties.insert("tokenDecimals".into(), TOKEN_DECIMALS.into());
 	properties.insert("tokenSymbol".into(), TOKEN_SYMBOL.into());
 
-	#[allow(deprecated)]
-	Ok(ChainSpec::from_genesis(
-		// Name
-		"HydraDX testnet",
-		// ID
-		"hydra_rococo",
-		ChainType::Live,
-		move || {
-			parachain_genesis(
-				// Sudo account
-				// Galactic Council
-				// 7JcAAB6cXQxVQyVLksPUdthJwcoEGm8SW9hsNgdP6hjme5J1
-				hex!["2cb1a0ef4ce819893905e3a6a8e46b652c43aee6c154921220902cabfdcfdd07"].into(),
-				// initial authorities & invulnerable collators
+	let genesis_json = parachain_genesis(
+		// Sudo account
+		// Galactic Council
+		// 7JcAAB6cXQxVQyVLksPUdthJwcoEGm8SW9hsNgdP6hjme5J1
+		hex!["2cb1a0ef4ce819893905e3a6a8e46b652c43aee6c154921220902cabfdcfdd07"].into(),
+		// initial authorities & invulnerable collators
+		(
+			vec![
 				(
-					vec![
-						(
-							// 5DvFqJq182asuR9EKoBBJBGEnZwpMHvuBrYpiMdr4hS8B6Eh
-							hex!["5206e6a18c96bab98f459ab636226481699220cf94346d766cd1142557a2fc66"].into(),
-							hex!["5206e6a18c96bab98f459ab636226481699220cf94346d766cd1142557a2fc66"].unchecked_into(),
-						),
-						(
-							// 5Fbc5bQp1bHfNpx8yuTshYK1pNhBbajZyaosRNvuyM3KRiMz
-							hex!["9c45dc3b15cd55531cad1e4c21cacb47611be54e3da6bf5be451f5e578a68344"].into(),
-							hex!["9c45dc3b15cd55531cad1e4c21cacb47611be54e3da6bf5be451f5e578a68344"].unchecked_into(),
-						),
-						(
-							// 5CAP1unPwP9RnvNcJn7YSZy1A8Snv5fGebuWMU99vpaJcfjh
-							hex!["04540c9406af2f5bf34f948dd1c7f029892247c2e1472b7cd51c188e4e0c2f2b"].into(),
-							hex!["04540c9406af2f5bf34f948dd1c7f029892247c2e1472b7cd51c188e4e0c2f2b"].unchecked_into(),
-						),
-						(
-							// 5GrzdLdMFuV6ZvWQjYUhVEpZQFoSxkLboKY3xeEdEjNUPoH7
-							hex!["d43ead05edb218c199fc0dfe36ec9389f509d8447e43109e1cb04305de4f9359"].into(),
-							hex!["d43ead05edb218c199fc0dfe36ec9389f509d8447e43109e1cb04305de4f9359"].unchecked_into(),
-						),
-						(
-							// 5G9gRv1GE8HPsjXnNm8By2SWuasTan5gU2AZm8pundyduHTM
-							hex!["b4bc5b99d9207ab2aadd222581809b53372e7e17c4eaa88742f3501f3044bf27"].into(),
-							hex!["b4bc5b99d9207ab2aadd222581809b53372e7e17c4eaa88742f3501f3044bf27"].unchecked_into(),
-						),
-					],
-					10_000 * UNITS,
+					// 5DvFqJq182asuR9EKoBBJBGEnZwpMHvuBrYpiMdr4hS8B6Eh
+					hex!["5206e6a18c96bab98f459ab636226481699220cf94346d766cd1142557a2fc66"].into(),
+					hex!["5206e6a18c96bab98f459ab636226481699220cf94346d766cd1142557a2fc66"].unchecked_into(),
 				),
-				// Pre-funded accounts
-				vec![(
-					// Galactic Council
-					// 7JcAAB6cXQxVQyVLksPUdthJwcoEGm8SW9hsNgdP6hjme5J1
-					hex!["2cb1a0ef4ce819893905e3a6a8e46b652c43aee6c154921220902cabfdcfdd07"].into(),
-					1_500_000_000,
-				)],
-				// council members
-				// GC - same as sudo
-				vec![hex!["2cb1a0ef4ce819893905e3a6a8e46b652c43aee6c154921220902cabfdcfdd07"].into()],
-				// technical committee
-				// GC - same as sudo
-				vec![hex!["2cb1a0ef4ce819893905e3a6a8e46b652c43aee6c154921220902cabfdcfdd07"].into()],
-				// vestings
-				vec![],
-				// registered_assets
-				vec![],
-				// accepted_assets
-				vec![],
-				// token balances
-				vec![],
-				// claims data
-				Default::default(),
-				// elections
-				vec![(
-					hex!["2cb1a0ef4ce819893905e3a6a8e46b652c43aee6c154921220902cabfdcfdd07"].into(),
-					1_200_000_000 * UNITS,
-				)],
-				// parachain ID
-				PARA_ID.into(),
-				// duster
-				DusterConfig {
-					// treasury
-					account_blacklist: vec![
-						hex!["6d6f646c70792f74727372790000000000000000000000000000000000000000"].into()
-					],
-					reward_account: Some(
-						hex!["6d6f646c70792f74727372790000000000000000000000000000000000000000"].into(),
-					),
-					dust_account: Some(hex!["6d6f646c70792f74727372790000000000000000000000000000000000000000"].into()),
-				},
-			)
-		},
-		// Bootnodes
-		vec![
-			"/dns/rococo-hydradx-p2p01.hydration.dev/tcp/30333/p2p/12D3KooWCtBQpwnWV7yMaEyBRkcAcAej78Q2uZawk5RcDrYktVQS"
-				.parse()
-				.unwrap(),
-			"/dns/rococo-hydradx-p2p02.hydration.dev/tcp/30333/p2p/12D3KooWLfojmwK6cAFDhzewCjUsyzYAKrpL4Ze42D1bLo8gvS4j"
-				.parse()
-				.unwrap(),
-			"/dns/rococo-hydradx-p2p03.hydration.dev/tcp/30333/p2p/12D3KooWEuEVHGrntL4Anje1k9z85V7thwhgPd9WnX4EJP5i13Xc"
-				.parse()
-				.unwrap(),
-		],
-		// Telemetry
-		Some(
-			TelemetryEndpoints::new(vec![
-				(_TELEMETRY_URLS[0].to_string(), 0),
-				(_TELEMETRY_URLS[1].to_string(), 0),
-			])
-			.expect("Telemetry url is valid"),
+				(
+					// 5Fbc5bQp1bHfNpx8yuTshYK1pNhBbajZyaosRNvuyM3KRiMz
+					hex!["9c45dc3b15cd55531cad1e4c21cacb47611be54e3da6bf5be451f5e578a68344"].into(),
+					hex!["9c45dc3b15cd55531cad1e4c21cacb47611be54e3da6bf5be451f5e578a68344"].unchecked_into(),
+				),
+				(
+					// 5CAP1unPwP9RnvNcJn7YSZy1A8Snv5fGebuWMU99vpaJcfjh
+					hex!["04540c9406af2f5bf34f948dd1c7f029892247c2e1472b7cd51c188e4e0c2f2b"].into(),
+					hex!["04540c9406af2f5bf34f948dd1c7f029892247c2e1472b7cd51c188e4e0c2f2b"].unchecked_into(),
+				),
+				(
+					// 5GrzdLdMFuV6ZvWQjYUhVEpZQFoSxkLboKY3xeEdEjNUPoH7
+					hex!["d43ead05edb218c199fc0dfe36ec9389f509d8447e43109e1cb04305de4f9359"].into(),
+					hex!["d43ead05edb218c199fc0dfe36ec9389f509d8447e43109e1cb04305de4f9359"].unchecked_into(),
+				),
+				(
+					// 5G9gRv1GE8HPsjXnNm8By2SWuasTan5gU2AZm8pundyduHTM
+					hex!["b4bc5b99d9207ab2aadd222581809b53372e7e17c4eaa88742f3501f3044bf27"].into(),
+					hex!["b4bc5b99d9207ab2aadd222581809b53372e7e17c4eaa88742f3501f3044bf27"].unchecked_into(),
+				),
+			],
+			10_000 * UNITS,
 		),
-		// Protocol ID
-		Some(PROTOCOL_ID),
-		// Fork ID
-		None,
-		// Properties
-		Some(properties),
-		// Extensions
+		// Pre-funded accounts
+		vec![(
+			// Galactic Council
+			// 7JcAAB6cXQxVQyVLksPUdthJwcoEGm8SW9hsNgdP6hjme5J1
+			hex!["2cb1a0ef4ce819893905e3a6a8e46b652c43aee6c154921220902cabfdcfdd07"].into(),
+			1_500_000_000,
+		)],
+		// council members
+		// GC - same as sudo
+		vec![hex!["2cb1a0ef4ce819893905e3a6a8e46b652c43aee6c154921220902cabfdcfdd07"].into()],
+		// technical committee
+		// GC - same as sudo
+		vec![hex!["2cb1a0ef4ce819893905e3a6a8e46b652c43aee6c154921220902cabfdcfdd07"].into()],
+		// vestings
+		vec![],
+		// registered_assets
+		vec![],
+		// accepted_assets
+		vec![],
+		// token balances
+		vec![],
+		// claims data
+		Default::default(),
+		// elections
+		vec![(
+			hex!["2cb1a0ef4ce819893905e3a6a8e46b652c43aee6c154921220902cabfdcfdd07"].into(),
+			1_200_000_000 * UNITS,
+		)],
+		// parachain ID
+		PARA_ID.into(),
+		// duster
+		DusterConfig {
+			// treasury
+			account_blacklist: vec![hex!["6d6f646c70792f74727372790000000000000000000000000000000000000000"].into()],
+			reward_account: Some(hex!["6d6f646c70792f74727372790000000000000000000000000000000000000000"].into()),
+			dust_account: Some(hex!["6d6f646c70792f74727372790000000000000000000000000000000000000000"].into()),
+		},
+	);
+
+	let chain_spec = ChainSpec::builder(
+		wasm_binary,
 		Extensions {
 			relay_chain: "rococo".into(),
 			para_id: PARA_ID,
 			evm_since: 1,
 		},
-		wasm_binary,
-	))
+	)
+	.with_name("HydraDX testnet")
+	.with_id("hydra_rococo")
+	.with_chain_type(ChainType::Live)
+	.with_boot_nodes(vec![
+		"/dns/rococo-hydradx-p2p01.hydration.dev/tcp/30333/p2p/12D3KooWCtBQpwnWV7yMaEyBRkcAcAej78Q2uZawk5RcDrYktVQS"
+			.parse()
+			.unwrap(),
+		"/dns/rococo-hydradx-p2p02.hydration.dev/tcp/30333/p2p/12D3KooWLfojmwK6cAFDhzewCjUsyzYAKrpL4Ze42D1bLo8gvS4j"
+			.parse()
+			.unwrap(),
+		"/dns/rococo-hydradx-p2p03.hydration.dev/tcp/30333/p2p/12D3KooWEuEVHGrntL4Anje1k9z85V7thwhgPd9WnX4EJP5i13Xc"
+			.parse()
+			.unwrap(),
+	])
+	.with_telemetry_endpoints(
+		TelemetryEndpoints::new(vec![
+			(_TELEMETRY_URLS[0].to_string(), 0),
+			(_TELEMETRY_URLS[1].to_string(), 0),
+		])
+		.expect("Telemetry url is valid"),
+	)
+	.with_properties(properties)
+	.with_protocol_id(PROTOCOL_ID)
+	.with_genesis_config_patch(genesis_json)
+	.build();
+
+	Ok(chain_spec)
 }

--- a/node/src/chain_spec/staging.rs
+++ b/node/src/chain_spec/staging.rs
@@ -15,124 +15,113 @@ pub fn parachain_config() -> Result<ChainSpec, String> {
 	properties.insert("tokenDecimals".into(), TOKEN_DECIMALS.into());
 	properties.insert("tokenSymbol".into(), TOKEN_SYMBOL.into());
 
-	#[allow(deprecated)]
-	Ok(ChainSpec::from_genesis(
-		// Name
-		"HydraDX",
-		// ID
-		"hydra",
-		ChainType::Live,
-		move || {
-			parachain_genesis(
-				// Sudo account
-				// Galactic Council
-				// 7HqdGVRB4MXz1osLR77mfWoo536cWasTYsuAbVuicHdiKQXf
-				hex!["0abad795adcb5dee45d29528005b1f78d55fc170844babde88df84016c6cd14d"].into(),
-				// initial authorities & invulnerable collators
+	let genesis_json = parachain_genesis(
+		// Sudo account
+		// Galactic Council
+		// 7HqdGVRB4MXz1osLR77mfWoo536cWasTYsuAbVuicHdiKQXf
+		hex!["0abad795adcb5dee45d29528005b1f78d55fc170844babde88df84016c6cd14d"].into(),
+		// initial authorities & invulnerable collators
+		(
+			vec![
 				(
-					vec![
-						(
-							// 5G3t6yhAonQHGUEqrByWQPgP9R8fcSSL6Vujphc89ysdTpKF
-							hex!["b0502e92d738d528922e8963b8a58a3c7c3b693db51b0972a6981836d67b8835"].into(),
-							hex!["b0502e92d738d528922e8963b8a58a3c7c3b693db51b0972a6981836d67b8835"].unchecked_into(),
-						),
-						(
-							// 5CVBHPAjhcVVAvL3AYpa9MB6kWDwoJbBwu7q4MqbhKwNnrV4
-							hex!["12aa36d6c1b055b9a7ab5d39f4fd9a9fe42912163c90e122fb7997e890a53d7e"].into(),
-							hex!["12aa36d6c1b055b9a7ab5d39f4fd9a9fe42912163c90e122fb7997e890a53d7e"].unchecked_into(),
-						),
-						(
-							// 5DFGmHjpxS6Xveg4YDw2hSp62JJ9h8oLCkeZUAoVR7hVtQ3k
-							hex!["344b7693389189ad0be0c83630b02830a568f7cb0f2d4b3483bcea323cc85f70"].into(),
-							hex!["344b7693389189ad0be0c83630b02830a568f7cb0f2d4b3483bcea323cc85f70"].unchecked_into(),
-						),
-						(
-							// 5H178NL4DLM9DGgAgZz1kbrX2TReP3uPk7svPtsg1VcYnuXH
-							hex!["da6e859211b1140369a73af533ecea4e4c0e985ad122ac4c663cc8b81d4fcd12"].into(),
-							hex!["da6e859211b1140369a73af533ecea4e4c0e985ad122ac4c663cc8b81d4fcd12"].unchecked_into(),
-						),
-						(
-							// 5Ca1iV2RNV253FzYJo12XtKJMPWCjv5CsPK9HdmwgJarD1sJ
-							hex!["165a3c2eb21341bf170fd1fa728bd9a7d02b7dc3b4968a46f2b1d494ee8c2b5d"].into(),
-							hex!["165a3c2eb21341bf170fd1fa728bd9a7d02b7dc3b4968a46f2b1d494ee8c2b5d"].unchecked_into(),
-						),
-					],
-					10_000 * UNITS,
+					// 5G3t6yhAonQHGUEqrByWQPgP9R8fcSSL6Vujphc89ysdTpKF
+					hex!["b0502e92d738d528922e8963b8a58a3c7c3b693db51b0972a6981836d67b8835"].into(),
+					hex!["b0502e92d738d528922e8963b8a58a3c7c3b693db51b0972a6981836d67b8835"].unchecked_into(),
 				),
-				// Pre-funded accounts
-				vec![(
-					// Galactic Council
-					// 7HqdGVRB4MXz1osLR77mfWoo536cWasTYsuAbVuicHdiKQXf
-					hex!["0abad795adcb5dee45d29528005b1f78d55fc170844babde88df84016c6cd14d"].into(),
-					1_500_000_000 * UNITS,
-				)],
-				// council members
-				vec![],
-				// technical committee
-				vec![],
-				// vestings
-				vec![],
-				// registered_assets
-				vec![],
-				// accepted_assets
-				vec![],
-				// token balances
-				vec![],
-				// claims data
-				Default::default(),
-				// elections
-				vec![
-					(get_account_id_from_seed::<sr25519::Public>("Alice"), STASH / 5),
-					(get_account_id_from_seed::<sr25519::Public>("Bob"), STASH / 5),
-					(get_account_id_from_seed::<sr25519::Public>("Eve"), STASH / 5),
-				],
-				// parachain ID
-				PARA_ID.into(),
-				// duster
-				DusterConfig {
-					// treasury
-					account_blacklist: vec![
-						hex!["6d6f646c70792f74727372790000000000000000000000000000000000000000"].into()
-					],
-					reward_account: Some(
-						hex!["6d6f646c70792f74727372790000000000000000000000000000000000000000"].into(),
-					),
-					dust_account: Some(hex!["6d6f646c70792f74727372790000000000000000000000000000000000000000"].into()),
-				},
-			)
-		},
-		// Bootnodes
-		vec![
-			"/dns/p2p-01.hydra.hydradx.io/tcp/30333/p2p/12D3KooWHzv7XVVBwY4EX1aKJBU6qzEjqGk6XtoFagr5wEXx6MsH"
-				.parse()
-				.unwrap(),
-			"/dns/p2p-02.hydra.hydradx.io/tcp/30333/p2p/12D3KooWR72FwHrkGNTNes6U5UHQezWLmrKu6b45MvcnRGK8J3S6"
-				.parse()
-				.unwrap(),
-			"/dns/p2p-03.hydra.hydradx.io/tcp/30333/p2p/12D3KooWFDwxZinAjgmLVgsideCmdB2bz911YgiQdLEiwKovezUz"
-				.parse()
-				.unwrap(),
-		],
-		// Telemetry
-		Some(
-			TelemetryEndpoints::new(vec![
-				(TELEMETRY_URLS[0].to_string(), 0),
-				(TELEMETRY_URLS[1].to_string(), 0),
-			])
-			.expect("Telemetry url is valid"),
+				(
+					// 5CVBHPAjhcVVAvL3AYpa9MB6kWDwoJbBwu7q4MqbhKwNnrV4
+					hex!["12aa36d6c1b055b9a7ab5d39f4fd9a9fe42912163c90e122fb7997e890a53d7e"].into(),
+					hex!["12aa36d6c1b055b9a7ab5d39f4fd9a9fe42912163c90e122fb7997e890a53d7e"].unchecked_into(),
+				),
+				(
+					// 5DFGmHjpxS6Xveg4YDw2hSp62JJ9h8oLCkeZUAoVR7hVtQ3k
+					hex!["344b7693389189ad0be0c83630b02830a568f7cb0f2d4b3483bcea323cc85f70"].into(),
+					hex!["344b7693389189ad0be0c83630b02830a568f7cb0f2d4b3483bcea323cc85f70"].unchecked_into(),
+				),
+				(
+					// 5H178NL4DLM9DGgAgZz1kbrX2TReP3uPk7svPtsg1VcYnuXH
+					hex!["da6e859211b1140369a73af533ecea4e4c0e985ad122ac4c663cc8b81d4fcd12"].into(),
+					hex!["da6e859211b1140369a73af533ecea4e4c0e985ad122ac4c663cc8b81d4fcd12"].unchecked_into(),
+				),
+				(
+					// 5Ca1iV2RNV253FzYJo12XtKJMPWCjv5CsPK9HdmwgJarD1sJ
+					hex!["165a3c2eb21341bf170fd1fa728bd9a7d02b7dc3b4968a46f2b1d494ee8c2b5d"].into(),
+					hex!["165a3c2eb21341bf170fd1fa728bd9a7d02b7dc3b4968a46f2b1d494ee8c2b5d"].unchecked_into(),
+				),
+			],
+			10_000 * UNITS,
 		),
-		// Protocol ID
-		Some(PROTOCOL_ID),
-		// Fork ID
-		None,
-		// Properties
-		Some(properties),
-		// Extensions
+		// Pre-funded accounts
+		vec![(
+			// Galactic Council
+			// 7HqdGVRB4MXz1osLR77mfWoo536cWasTYsuAbVuicHdiKQXf
+			hex!["0abad795adcb5dee45d29528005b1f78d55fc170844babde88df84016c6cd14d"].into(),
+			1_500_000_000 * UNITS,
+		)],
+		// council members
+		vec![],
+		// technical committee
+		vec![],
+		// vestings
+		vec![],
+		// registered_assets
+		vec![],
+		// accepted_assets
+		vec![],
+		// token balances
+		vec![],
+		// claims data
+		Default::default(),
+		// elections
+		vec![
+			(get_account_id_from_seed::<sr25519::Public>("Alice"), STASH / 5),
+			(get_account_id_from_seed::<sr25519::Public>("Bob"), STASH / 5),
+			(get_account_id_from_seed::<sr25519::Public>("Eve"), STASH / 5),
+		],
+		// parachain ID
+		PARA_ID.into(),
+		// duster
+		DusterConfig {
+			// treasury
+			account_blacklist: vec![hex!["6d6f646c70792f74727372790000000000000000000000000000000000000000"].into()],
+			reward_account: Some(hex!["6d6f646c70792f74727372790000000000000000000000000000000000000000"].into()),
+			dust_account: Some(hex!["6d6f646c70792f74727372790000000000000000000000000000000000000000"].into()),
+		},
+	);
+
+	let chain_spec = ChainSpec::builder(
+		wasm_binary,
 		Extensions {
 			relay_chain: "polkadot".into(),
 			para_id: PARA_ID,
 			evm_since: 1,
 		},
-		wasm_binary,
-	))
+	)
+	.with_name("HydraDX")
+	.with_id("hydra")
+	.with_chain_type(ChainType::Live)
+	.with_boot_nodes(vec![
+		"/dns/p2p-01.hydra.hydradx.io/tcp/30333/p2p/12D3KooWHzv7XVVBwY4EX1aKJBU6qzEjqGk6XtoFagr5wEXx6MsH"
+			.parse()
+			.unwrap(),
+		"/dns/p2p-02.hydra.hydradx.io/tcp/30333/p2p/12D3KooWR72FwHrkGNTNes6U5UHQezWLmrKu6b45MvcnRGK8J3S6"
+			.parse()
+			.unwrap(),
+		"/dns/p2p-03.hydra.hydradx.io/tcp/30333/p2p/12D3KooWFDwxZinAjgmLVgsideCmdB2bz911YgiQdLEiwKovezUz"
+			.parse()
+			.unwrap(),
+	])
+	.with_telemetry_endpoints(
+		TelemetryEndpoints::new(vec![
+			(TELEMETRY_URLS[0].to_string(), 0),
+			(TELEMETRY_URLS[1].to_string(), 0),
+		])
+		.expect("Telemetry url is valid"),
+	)
+	.with_properties(properties)
+	.with_protocol_id(PROTOCOL_ID)
+	.with_genesis_config_patch(genesis_json)
+	.build();
+
+	Ok(chain_spec)
 }

--- a/runtime/hydradx/Cargo.toml
+++ b/runtime/hydradx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-runtime"
-version = "242.0.0"
+version = "243.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 license = "Apache 2.0"
@@ -127,6 +127,7 @@ frame-system-rpc-runtime-api = { workspace = true }
 frame-try-runtime = { workspace = true, optional = true }
 sp-api = { workspace = true }
 sp-block-builder = { workspace = true }
+sp-genesis-builder = { workspace = true }
 sp-consensus-aura = { workspace = true }
 sp-core = { workspace = true }
 sp-inherents = { workspace = true }
@@ -284,6 +285,7 @@ std = [
     "warehouse-liquidity-mining/std",
     "sp-api/std",
     "sp-block-builder/std",
+    "sp-genesis-builder/std",
     "sp-consensus-aura/std",
     "sp-core/std",
     "sp-io/std",

--- a/runtime/hydradx/src/assets.rs
+++ b/runtime/hydradx/src/assets.rs
@@ -24,10 +24,10 @@ use hydradx_adapters::{
 	StableswapHooksAdapter, VestingInfo,
 };
 
-use hydradx_traits::{
+pub use hydradx_traits::{
 	registry::Inspect,
 	router::{inverse_route, PoolType, Trade},
-	AccountIdFor, AssetKind, AssetPairAccountIdFor, NativePriceOracle, OnTradeHandler, OraclePeriod, Source,
+	AccountIdFor, AssetKind, AssetPairAccountIdFor, Liquidity, NativePriceOracle, OnTradeHandler, OraclePeriod, Source,
 };
 use pallet_currencies::BasicCurrencyAdapter;
 use pallet_omnipool::{

--- a/runtime/hydradx/src/evm/mod.rs
+++ b/runtime/hydradx/src/evm/mod.rs
@@ -27,6 +27,7 @@ pub use crate::{
 	AssetLocation, Aura, NORMAL_DISPATCH_RATIO,
 };
 use crate::{NativeAssetId, LRNA};
+pub use fp_evm::GenesisAccount as EvmGenesisAccount;
 use frame_support::{
 	parameter_types,
 	traits::{Defensive, FindAuthor},

--- a/runtime/hydradx/src/lib.rs
+++ b/runtime/hydradx/src/lib.rs
@@ -63,12 +63,19 @@ use sp_std::{convert::From, prelude::*};
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 // A few exports that help ease life for downstream crates.
-use frame_support::{construct_runtime, pallet_prelude::Hooks, parameter_types, weights::Weight};
+use frame_support::{
+	construct_runtime,
+	genesis_builder_helper::{build_config, create_default_config},
+	pallet_prelude::Hooks,
+	parameter_types,
+	weights::Weight,
+};
 pub use hex_literal::hex;
 /// Import HydraDX pallets
 pub use pallet_claims;
 use pallet_ethereum::{Transaction as EthereumTransaction, TransactionStatus};
 use pallet_evm::{Account as EVMAccount, FeeCalculator, GasWeightMapping, Runner};
+pub use pallet_genesis_history::Chain;
 pub use primitives::{
 	AccountId, Amount, AssetId, Balance, BlockNumber, CollectionId, Hash, Index, ItemId, Price, Signature,
 };
@@ -107,7 +114,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hydradx"),
 	impl_name: create_runtime_str!("hydradx"),
 	authoring_version: 1,
-	spec_version: 242,
+	spec_version: 243,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -809,6 +816,16 @@ impl_runtime_apis! {
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)
+		}
+	}
+
+	impl sp_genesis_builder::GenesisBuilder<Block> for Runtime {
+		fn create_default_config() -> Vec<u8> {
+			create_default_config::<RuntimeGenesisConfig>()
+		}
+
+		fn build_config(config: Vec<u8>) -> sp_genesis_builder::Result {
+			build_config::<RuntimeGenesisConfig>(config)
 		}
 	}
 }

--- a/runtime/hydradx/src/xcm.rs
+++ b/runtime/hydradx/src/xcm.rs
@@ -17,6 +17,7 @@ use hydradx_adapters::{xcm_exchange::XcmAssetExchanger, xcm_execute_filter::Allo
 use orml_traits::{location::AbsoluteReserveProvider, parameter_type_with_key};
 use orml_xcm_support::{DepositToAlternative, IsNativeConcrete, MultiNativeAsset};
 use pallet_evm::AddressMapping;
+pub use pallet_xcm::GenesisConfig as XcmGenesisConfig;
 use pallet_xcm::XcmPassthrough;
 use parachains_common::message_queue::{NarrowOriginToSibling, ParaIdToSibling};
 use polkadot_parachain::primitives::{RelayChainBlockNumber, Sibling};


### PR DESCRIPTION
Fixes: #813. This PR removes deprecated method `from_genesis` and replaces it with `builder`.